### PR TITLE
Fix phplint workflow if-condition syntax

### DIFF
--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -74,13 +74,13 @@ jobs:
           rm ./auth.json
 
       - name: PHP Lint 8.0+
-        if: ( ${{ inputs.php_version }} == 8.0 || ${{ inputs.php_version }} == 8.2 ) && ${{ steps.check_commit_message.outputs.skip_lint }} != 'true'" 
+        if: (inputs.php_version == '8.0' || inputs.php_version == '8.2') && steps.check_commit_message.outputs.skip_lint != 'true'
         uses: overtrue/phplint@9.0
         with:
           path: .
 
       - name: PHP Lint 7.4
-        if: ${{ inputs.php_version }} == 7.4 && ${{ steps.check_commit_message.outputs.skip_lint }} != 'true'"
+        if: inputs.php_version == '7.4' && steps.check_commit_message.outputs.skip_lint != 'true'
         uses: overtrue/phplint@3.4.0
         with:
           path: .


### PR DESCRIPTION
## Summary
- Fix malformed `if` conditions on the "PHP Lint 8.0+" and "PHP Lint 7.4" steps in `phplint.yml`
- The old expressions mixed literal text with `${{ }}` tokens (e.g. `( ${{ inputs.php_version }} == 8.0 ...)`), which GitHub Actions evaluates as always truthy and emits a syntax warning
- Replaced with proper expressions where the entire condition is evaluated as a workflow expression

## What was wrong
```yaml
# Before (broken) — literal text outside ${{ }} tokens
if: ( ${{ inputs.php_version }} == 8.0 || ${{ inputs.php_version }} == 8.2 ) && ${{ steps.check_commit_message.outputs.skip_lint }} != 'true'"
```

```yaml
# After (fixed) — clean expression, version values quoted as strings
if: (inputs.php_version == '8.0' || inputs.php_version == '8.2') && steps.check_commit_message.outputs.skip_lint != 'true'
```

This was surfacing as a workflow syntax warning in downstream repos (e.g. resourcingedge) that call this reusable workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)