### PR TITLE
feat: add composer validate gate to catch lock drift early

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # Defense in depth: a desynced lock should be caught on the PR by
+      # validate-composer.yml, but if one ever reaches a release build this
+      # fails in seconds with a clear message — before the long install — rather
+      # than crashing partway through `composer install`. composer is
+      # preinstalled on hosted runners, so this runs before the PHP setup below.
+      - name: Validate composer.lock is in sync with composer.json
+        run: |
+          set -uo pipefail
+          status=0
+          for dir in . themes/* plugins/*; do
+            if [ -f "$dir/composer.json" ] && [ -f "$dir/composer.lock" ]; then
+              if ! composer validate --no-check-all --no-check-publish --working-dir="$dir"; then
+                echo "::error::composer.lock in '$dir' is out of sync with its composer.json — run 'composer update' in $dir and commit the lock. A tagged release was already cut; fix this and roll a new release."
+                status=1
+              fi
+            fi
+          done
+          exit $status
+
       - name: Setup PHP and install project Composer dependencies
         if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'false' }}
         uses: linchpin/actions/actions/setup-wp-php@v4

--- a/.github/workflows/validate-composer.yml
+++ b/.github/workflows/validate-composer.yml
@@ -1,0 +1,69 @@
+# Validate Composer (v4)
+#
+# A fast, always-runs gate that fails when a composer.lock is out of sync with
+# its composer.json — a locked version no longer satisfies a constraint, or
+# composer.json changed without a lock rebuild. That is the exact failure that
+# otherwise stays hidden until release-build time: create-release runs
+# `composer install`, it errors with "the lock file is not up to date", no
+# release.zip is attached, and the production deploy dies with "no assets to
+# download" — after release-please has already cut the tag. Catching it on the
+# PR means the bad lock never reaches main, so the doomed release is never cut.
+#
+# Why not `--strict`: this project family keeps a `version` field in
+# composer.json (managed by release-please) and pins some wpackagist plugins to
+# exact versions. `--strict` escalates those benign warnings to errors and the
+# gate would fail on a perfectly in-sync lock. `--no-check-all` drops the
+# constraint-strictness warnings and `--no-check-publish` drops the
+# publish-readiness warnings; the lock-freshness check still fails the run
+# (composer validate exits 2) when the lock has actually drifted.
+#
+# Validates the root composer.json plus every themes/* and plugins/* package
+# that ships its own lock, since build.yml installs each of those too.
+
+name: Validate Composer
+
+on:
+  workflow_call:
+    inputs:
+      php_version:
+        description: "PHP version. Defaults to vars.PHP_VERSION, then 8.5"
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  validate:
+    name: composer validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # No Composer install here on purpose — `composer validate` only parses
+      # composer.json/composer.lock, so the gate stays fast (~seconds) and needs
+      # no Packagist credentials.
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php_version || vars.PHP_VERSION || '8.5' }}
+          coverage: none
+          tools: composer
+
+      - name: Validate composer.lock is in sync with composer.json
+        run: |
+          set -uo pipefail
+          status=0
+          for dir in . themes/* plugins/*; do
+            if [ -f "$dir/composer.json" ] && [ -f "$dir/composer.lock" ]; then
+              echo "::group::composer validate ($dir)"
+              if ! composer validate --no-check-all --no-check-publish --working-dir="$dir"; then
+                echo "::error::composer.lock in '$dir' is out of sync with its composer.json. Run 'composer update' (or 'composer update <package>') in $dir and commit the updated composer.lock."
+                status=1
+              fi
+              echo "::endgroup::"
+            fi
+          done
+          exit $status


### PR DESCRIPTION
## Problem

A desynced `composer.lock` (a locked version no longer satisfies `composer.json`, or `composer.json` changed without a lock rebuild) stays hidden until **release-build time**: `create-release` runs `composer install`, it fails with *"the lock file is not up to date"*, no `release.zip` is attached, and the production deploy dies with `no assets to download` — **after** release-please has already cut the tag. (This just bit `linchpin/linchpin.com` v0.1.58.)

## Change

- **New reusable workflow `validate-composer.yml`** — a fast, install-free `composer validate` over the root and every `themes/*` / `plugins/*` package that ships a lock. No Composer install, no Packagist auth, runs in seconds. Callers wire it as an **always-runs, required** PR check (including on `dependabot/`, `renovate/`, `release-please--` branches, which typically skip lint), so a bad lock never reaches `main` and no doomed release is cut.
- **`build.yml` preflight** — the same validation as the first build step (defense in depth): if a desynced lock ever reaches a release build, it fails in seconds with a clear message instead of crashing partway through `composer install`.

## Why not `--strict`

`composer.json` keeps a release-please-managed `version` field and pins some wpackagist plugins to exact versions; `--strict` escalates those benign warnings to errors and would fail an in-sync lock. `--no-check-all` / `--no-check-publish` drop them while the lock-freshness check still fails the run (`composer validate` exits 2) when the lock has actually drifted. Verified locally: exit 0 on a synced lock, exit 2 on a stale one.

## Rollout

Ship as **v4.0.3 / v4.x** and move the floating `v4` tag (via the existing `update-major-tag` release flow). Consumers then add a workflow that calls `validate-composer.yml@v4` on every PR and mark its check required.