### PR TITLE
feat: publish release after asset attach (draft-safe) and trim deploy wait

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,3 +218,20 @@ jobs:
           cd release && zip -rq "$GITHUB_WORKSPACE/release.zip" ./ && cd "$GITHUB_WORKSPACE"
           gh release upload "${{ inputs.release_tag }}" release.zip --clobber --repo "${{ github.repository }}"
           echo "::notice::release.zip attached to ${{ inputs.release_tag }} — deploys can now use it instead of rebuilding"
+
+      # Publish the release ONLY after release.zip is attached. When the caller
+      # configures release-please with `draft: true`, the release sits as an
+      # unpublished draft until this step, so the `release: published` event —
+      # and the production deploy that listens for it — does not fire until the
+      # asset exists. That makes the deploy deterministic (no polling for the
+      # asset, no billed idle time) and means a failed build leaves a harmless
+      # draft instead of a published tag with no asset. Idempotent and harmless
+      # for callers that do not use draft releases: `--draft=false` on an
+      # already-published release is a no-op.
+      - name: Publish release ${{ inputs.release_tag }} now that release.zip is attached
+        if: ${{ inputs.release_tag != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "${{ inputs.release_tag }}" --draft=false --repo "${{ github.repository }}"
+          echo "::notice::Published ${{ inputs.release_tag }} with release.zip attached — the production deploy can now start"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,13 +148,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # The `release: published` event and create-release's asset upload
-          # race: this deploy can start before create-release has finished
-          # building and attaching release.zip (~4 min). Wait for the asset
-          # rather than failing, then download it.
+          # With release-please `draft: true`, the release is published only
+          # after create-release has attached release.zip (see build.yml), so by
+          # the time `release: published` fires the asset is already present and
+          # the first download succeeds. This short retry is just a safety net
+          # for GitHub asset eventual-consistency (or a caller not using draft
+          # releases); it caps at ~2 min so a genuinely missing asset fails fast
+          # instead of billing ~10 min of idle polling.
           TAG="${{ inputs.release_tag }}"
           REPO="${{ github.repository }}"
-          for attempt in $(seq 1 40); do
+          for attempt in $(seq 1 8); do
             if gh release download "$TAG" --pattern release.zip --repo "$REPO" --clobber 2>/dev/null; then
               echo "::notice::Deploying prebuilt asset from release $TAG — no rebuild needed"
               mkdir -p release
@@ -162,10 +165,10 @@ jobs:
               rm -f release.zip
               exit 0
             fi
-            echo "release.zip not attached to $TAG yet (attempt $attempt/40) — waiting 15s for create-release to finish…"
+            echo "release.zip not on $TAG yet (attempt $attempt/8) — retrying in 15s…"
             sleep 15
           done
-          echo "::error::release.zip never appeared on $TAG after ~10 min. Did create-release@v4 run and succeed?"
+          echo "::error::release.zip never appeared on $TAG after ~2 min. Did create-release@v4 build, attach the asset, and publish the release?"
           exit 1
 
       # Backup-and-continue flow (Pressable, v3-compatible): trigger the


### PR DESCRIPTION
## Why

Production deploys currently start on `release: published`, which fires the instant release-please creates the release — minutes before `create-release` finishes attaching `release.zip`. v4.0.2 papered over the race with a ~10 min wait-loop, but on private repos that idle `sleep` is **billed runner time** (the recent v0.1.58 deploy billed ~11 min, almost all of it waiting).

## Change (pairs with release-please `draft: true` on the caller)

- **`build.yml`** publishes the release (`gh release edit --draft=false`) right after attaching `release.zip`. With `draft: true`, the release stays an unpublished draft until the asset exists, so `release: published` — and the deploy — fires only when there's something to deploy. Deterministic, zero idle billing, and a **failed build leaves a harmless draft** instead of a published tag with no asset. Idempotent for callers not using drafts (`--draft=false` on a published release is a no-op).
- **`deploy.yml`** wait-loop trimmed from `40 × 15s` (~10 min) to `8 × 15s` (~2 min) — now just a safety net for asset eventual-consistency. A genuinely missing asset fails fast instead of billing ~10 min of `sleep`.

## Rollout

Ship as **v4.1.1** and move `v4`. Callers then add `"draft": true` to `release-please-config.json` (must land *after* this is on `@v4`, or releases would never publish).