### PR TITLE
fix: validate composer lock with install, not validate (version-field churn)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,25 +79,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # Defense in depth: a desynced lock should be caught on the PR by
-      # validate-composer.yml, but if one ever reaches a release build this
-      # fails in seconds with a clear message — before the long install — rather
-      # than crashing partway through `composer install`. composer is
-      # preinstalled on hosted runners, so this runs before the PHP setup below.
-      - name: Validate composer.lock is in sync with composer.json
-        run: |
-          set -uo pipefail
-          status=0
-          for dir in . themes/* plugins/*; do
-            if [ -f "$dir/composer.json" ] && [ -f "$dir/composer.lock" ]; then
-              if ! composer validate --no-check-all --no-check-publish --working-dir="$dir"; then
-                echo "::error::composer.lock in '$dir' is out of sync with its composer.json — run 'composer update' in $dir and commit the lock. A tagged release was already cut; fix this and roll a new release."
-                status=1
-              fi
-            fi
-          done
-          exit $status
-
+      # NOTE: no `composer validate` preflight here. The install step below
+      # (`composer install --no-dev`) is itself the authoritative check — it
+      # fails when a locked version no longer satisfies composer.json. A
+      # `composer validate` preflight would be WRONG: release-please bumps the
+      # `version` field in composer.json on every release without rebuilding the
+      # lock, which `composer validate` rejects (content-hash mismatch) even
+      # though `composer install` correctly tolerates it (warns, succeeds). The
+      # PR-time gate (validate-composer.yml) uses `composer install` for the
+      # same reason.
       - name: Setup PHP and install project Composer dependencies
         if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'false' }}
         uses: linchpin/actions/actions/setup-wp-php@v4

--- a/.github/workflows/validate-composer.yml
+++ b/.github/workflows/validate-composer.yml
@@ -1,24 +1,25 @@
 # Validate Composer (v4)
 #
-# A fast, always-runs gate that fails when a composer.lock is out of sync with
-# its composer.json — a locked version no longer satisfies a constraint, or
-# composer.json changed without a lock rebuild. That is the exact failure that
-# otherwise stays hidden until release-build time: create-release runs
-# `composer install`, it errors with "the lock file is not up to date", no
-# release.zip is attached, and the production deploy dies with "no assets to
-# download" — after release-please has already cut the tag. Catching it on the
-# PR means the bad lock never reaches main, so the doomed release is never cut.
+# A PR-time gate that fails when composer.lock can no longer be installed against
+# composer.json — i.e. a locked package version no longer satisfies a constraint
+# (someone bumped a constraint in composer.json without rebuilding the lock).
+# That is the exact failure that otherwise stays hidden until release-build time:
+# create-release runs `composer install`, it exits non-zero, no release.zip is
+# attached, and (without draft releases) the production deploy dies with "no
+# assets to download" after release-please has already cut the tag. Catching it
+# on the PR means the bad lock never reaches main.
 #
-# Why not `--strict`: this project family keeps a `version` field in
-# composer.json (managed by release-please) and pins some wpackagist plugins to
-# exact versions. `--strict` escalates those benign warnings to errors and the
-# gate would fail on a perfectly in-sync lock. `--no-check-all` drops the
-# constraint-strictness warnings and `--no-check-publish` drops the
-# publish-readiness warnings; the lock-freshness check still fails the run
-# (composer validate exits 2) when the lock has actually drifted.
+# Why `composer install --dry-run` and NOT `composer validate`: release-please
+# bumps the `version` field in composer.json on every release without rebuilding
+# the lock. `composer validate` treats that benign content-hash mismatch as an
+# error (exit 2) and would fail every release PR and release build, while
+# `composer install` correctly tolerates it (warns, succeeds) and only fails on
+# a genuinely unsatisfiable lock. This gate therefore mirrors the build exactly.
 #
-# Validates the root composer.json plus every themes/* and plugins/* package
-# that ships its own lock, since build.yml installs each of those too.
+# Runs over the root composer.json plus every themes/* and plugins/* package
+# that ships its own lock, since build.yml installs each of those too. --no-dev
+# matches the release build (dev-only drift does not break a deploy and is
+# covered by lint.yml).
 
 name: Validate Composer
 
@@ -30,21 +31,22 @@ on:
         required: false
         default: ""
         type: string
+    secrets:
+      PACKAGIST_COMPOSER_AUTH_JSON:
+        description: "auth.json for packagist.linchpin.com (passed via COMPOSER_AUTH; needed to resolve private packages)"
+        required: false
 
 jobs:
   validate:
-    name: composer validate
+    name: composer install (lock satisfies composer.json?)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # No Composer install here on purpose — `composer validate` only parses
-      # composer.json/composer.lock, so the gate stays fast (~seconds) and needs
-      # no Packagist credentials.
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,15 +54,19 @@ jobs:
           coverage: none
           tools: composer
 
-      - name: Validate composer.lock is in sync with composer.json
+      - name: Dry-run install from each lock (no vendor written, no rebuild)
+        env:
+          # COMPOSER_AUTH lets the dry run resolve private packages
+          # (packagist.linchpin.com) without writing an auth.json to disk.
+          COMPOSER_AUTH: ${{ secrets.PACKAGIST_COMPOSER_AUTH_JSON }}
         run: |
           set -uo pipefail
           status=0
           for dir in . themes/* plugins/*; do
             if [ -f "$dir/composer.json" ] && [ -f "$dir/composer.lock" ]; then
-              echo "::group::composer validate ($dir)"
-              if ! composer validate --no-check-all --no-check-publish --working-dir="$dir"; then
-                echo "::error::composer.lock in '$dir' is out of sync with its composer.json. Run 'composer update' (or 'composer update <package>') in $dir and commit the updated composer.lock."
+              echo "::group::composer install --dry-run ($dir)"
+              if ! composer install --no-dev --dry-run --no-interaction --no-progress --working-dir="$dir"; then
+                echo "::error::composer.lock in '$dir' can no longer be installed against its composer.json (a locked version no longer satisfies a constraint). Run 'composer update' in $dir and commit the lock."
                 status=1
               fi
               echo "::endgroup::"


### PR DESCRIPTION
## Bug in 4.1.0

The `composer validate`-based gate (`validate-composer.yml`) and the `build.yml` preflight added in 4.1.0 are **too strict**: `composer validate` treats a `composer.json` whose `version` field changed without a lock rebuild as an error (content-hash mismatch, exit 2). **release-please bumps that `version` field on every release**, so both would falsely fail every release PR and every release build — even though `composer install` correctly tolerates the bump (warns, succeeds) and only fails on a genuinely unsatisfiable lock.

Verified locally (composer 2.9.8): on a version-bumped `composer.json`, `composer validate` → exit 2, `composer install --no-dev --dry-run` → exit 0.

## Fix

- `validate-composer.yml` now runs `composer install --no-dev --dry-run` over the root and each `themes/*` / `plugins/*` lock — the exact operation the release build performs, so it catches what would break the build and nothing else. Adds the `PACKAGIST_COMPOSER_AUTH_JSON` secret to resolve private packages.
- `build.yml` drops the preflight entirely — its own `composer install` is already the authoritative check; the preflight only added false failures.

Ship as a patch and move `v4`.