### PR TITLE
fix: publish release with GH_BOT_TOKEN so release:published triggers deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,15 @@ on:
       PACKAGIST_COMPOSER_AUTH_JSON:
         description: "auth.json contents for packagist.linchpin.com (passed via COMPOSER_AUTH, never written to disk)"
         required: false
+      GH_BOT_TOKEN:
+        description: >-
+          PAT used to PUBLISH the draft release. Events created by the default
+          GITHUB_TOKEN do not trigger new workflow runs, so publishing with
+          github.token leaves `release: published` consumers (e.g.
+          deploy-production.yml) unfired. Pass a PAT to make auto-deploy work;
+          falls back to github.token when unset (asset still attaches/publishes,
+          but the deploy must be triggered another way).
+        required: false
     outputs:
       artifact:
         description: "Name of the uploaded release artifact"
@@ -218,10 +227,17 @@ jobs:
       # draft instead of a published tag with no asset. Idempotent and harmless
       # for callers that do not use draft releases: `--draft=false` on an
       # already-published release is a no-op.
+      #
+      # Publish with GH_BOT_TOKEN (a PAT), NOT github.token: GitHub does not
+      # trigger new workflow runs from events created by the default
+      # GITHUB_TOKEN, so a draft published with github.token fires
+      # `release: published` that downstream workflows (deploy-production.yml)
+      # never see. Falls back to github.token when no PAT is provided — the
+      # release still publishes, but auto-deploy won't fire.
       - name: Publish release ${{ inputs.release_tag }} now that release.zip is attached
         if: ${{ inputs.release_tag != '' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_BOT_TOKEN || github.token }}
         run: |
           gh release edit "${{ inputs.release_tag }}" --draft=false --repo "${{ github.repository }}"
           echo "::notice::Published ${{ inputs.release_tag }} with release.zip attached — the production deploy can now start"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -33,13 +33,22 @@ on:
     secrets:
       PACKAGIST_COMPOSER_AUTH_JSON:
         required: false
+      GH_BOT_TOKEN:
+        description: >-
+          PAT forwarded to build.yml so it can PUBLISH the draft release with a
+          token that triggers downstream `release: published` workflows
+          (GITHUB_TOKEN-created events do not). Optional; build falls back to
+          github.token when unset.
+        required: false
 
 jobs:
   build:
     name: Build release asset
     uses: ./.github/workflows/build.yml
-    secrets:
-      PACKAGIST_COMPOSER_AUTH_JSON: ${{ secrets.PACKAGIST_COMPOSER_AUTH_JSON }}
+    # inherit (not an explicit map) so GH_BOT_TOKEN — needed by build.yml's
+    # publish step to fire the deploy — flows through alongside the Packagist
+    # auth without each secret being threaded by hand.
+    secrets: inherit
     with:
       release_tag: ${{ inputs.release_tag }}
       build_commands: ${{ inputs.build_commands }}


### PR DESCRIPTION
## Problem

The build's **Publish release** step published the draft with `GH_TOKEN: ${{ github.token }}`. GitHub **does not trigger new workflow runs from events created by the default `GITHUB_TOKEN`** (recursion prevention). So the `release: published` event fired internally but downstream consumers — notably consumers' `deploy-production.yml` (`on: release: [published]`) — **never ran**.

Observed on linchpin.com: v0.1.64 published cleanly with `release.zip` attached and the tag created, yet **zero** Deploy to Production runs triggered. (Pre-draft releases worked only because release-please itself published them with the bot PAT.)

## Fix

- **build.yml**: Publish step now uses `${{ secrets.GH_BOT_TOKEN || github.token }}`, and declares the `GH_BOT_TOKEN` `workflow_call` secret. Falls back to `github.token` when no PAT is supplied (release still publishes, but auto-deploy won't fire). The **asset-attach** step keeps `github.token` — uploading an asset doesn't need to trigger anything.
- **create-release.yml**: forwards secrets via `secrets: inherit` so the PAT reaches `build.yml`, and declares `GH_BOT_TOKEN` for explicit callers.

## Backward compatibility

- `GH_BOT_TOKEN` is `required: false` everywhere; callers without it get today's behavior (publishes, no auto-deploy).
- `deploy.yml`'s `build` call only runs when `release_tag == ''` (the rebuild fallback), where the Publish step is skipped — unaffected.

## Rollout

Merging this + the resulting release-please PR moves the floating `v4` tag. Consumers on `@v4` (e.g. linchpin.com, which already defines `GH_BOT_TOKEN` and calls `create-release` with `secrets: inherit`) get auto-deploy on the next release with no further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)