### PR TITLE
perf: speed up release build (artifact compression, drop node_modules rm, fast rollback zip)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,10 @@ jobs:
                   npm install --no-save sass-embedded-linux-x64 || true
                 fi
                 npm run build
-                rm -rf node_modules
+                # node_modules is intentionally NOT deleted here: the release
+                # assembler (build-release/cleanup.sh) and .distignore both
+                # already exclude it, so it never ships. Deleting ~1k dirs each
+                # build is pure wasted time.
               )
             fi
           done
@@ -173,7 +176,10 @@ jobs:
                 cd "$dir"
                 npm ci
                 npm run build
-                rm -rf node_modules
+                # node_modules is intentionally NOT deleted here: the release
+                # assembler (build-release/cleanup.sh) and .distignore both
+                # already exclude it, so it never ships. Deleting ~1k dirs each
+                # build is pure wasted time.
               )
             fi
             # Composer after npm so the runtime vendor/ ships in the release
@@ -200,6 +206,14 @@ jobs:
           path: release/
           retention-days: 1
           overwrite: true
+          # The release is thousands of small PHP files (every Composer-installed
+          # plugin/theme), and at the default level 6 deflate is the dominant
+          # cost of this step. This artifact lives one day and is consumed
+          # seconds later by the deploy job over GitHub's own network, so trade
+          # CPU for a little bandwidth: level 1 keeps it compressed (transfer
+          # stays small) while cutting the zip time sharply. Drop to 0 (store)
+          # to push upload speed further if the transfer is not the bottleneck.
+          compression-level: 1
 
       # Archive the deployable zip on the (already-published) GitHub release so
       # rollbacks/redeploys can download it instead of rebuilding. Publishing is
@@ -212,6 +226,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          cd release && zip -rq "$GITHUB_WORKSPACE/release.zip" ./ && cd "$GITHUB_WORKSPACE"
+          # -1 (fastest deflate): this is a rollback/redeploy archive, not a
+          # distribution artifact, so max compression buys nothing but burns
+          # CPU over thousands of plugin files.
+          cd release && zip -1 -rq "$GITHUB_WORKSPACE/release.zip" ./ && cd "$GITHUB_WORKSPACE"
           gh release upload "${{ inputs.release_tag }}" release.zip --clobber --repo "${{ github.repository }}"
           echo "::notice::release.zip archived on ${{ inputs.release_tag }} — available for rollback/redeploy"


### PR DESCRIPTION
## Why

The `Build` job in `deploy.yml` spends most of its ~3min wall time **zipping the release payload**, not building. Because the root `composer install --no-dev` materializes every plugin/theme (`composer/installers`), the release is thousands of small PHP files — and that payload gets compressed up to **three times** across build + deploy:

1. `upload-artifact` zips `release/` at the default deflate level 6 (~49s in a recent prod run)
2. the rollback `release.zip` zips the same content again (~21s)
3. `deploy-pressable` re-zips it for rsync

## What changed (`build.yml`, no behavior change)

- **Artifact `compression-level: 1`** — the `release` artifact has 1-day retention and is consumed seconds later by the deploy job over GitHub's own network, so deflate CPU was the dominant cost, not transfer. Level 1 keeps it compressed while sharply cutting zip time. (Comment notes `0`/store as a further option.)
- **Stop `rm -rf node_modules`** after each theme/plugin build — `build-release/cleanup.sh` and `.distignore` already exclude `node_modules`, so it never shipped; deleting ~1k dirs per build was pure waste.
- **Rollback `release.zip` uses `zip -1`** (fastest) instead of default deflate — it's an archive for redeploy, not a distribution artifact.

## Impact

Targets the two biggest steps in the build job (artifact upload + release attach). Expected to drop the build job from ~3m17s toward ~2m, with zero change to what ships.

## Not included (follow-ups discussed)

- Parallelizing the theme + plugin build steps (~25s, overlapping wall time)
- Single-zip end-to-end: zip once in build, ship that zip as the artifact and rsync it straight to the server — eliminates the double/triple zip and the slow many-file artifact transfer. Bigger win but touches `deploy.yml`, `deploy-continue.yml`, and the host actions, so it warrants its own PR + staging test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)