### PR TITLE
perf: ship one release zip end-to-end (single-file artifact, no re-zip on deploy)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,24 +199,40 @@ jobs:
         with:
           remote-plugin-install: ${{ vars.REMOTE_PLUGIN_INSTALL }}
 
+      # Package the release into ONE zip, here, once. The release is thousands
+      # of small PHP files (every Composer-installed plugin/theme), and that
+      # payload used to be compressed up to three times: upload-artifact zipped
+      # the directory, the attach step zipped it again, and each host action
+      # re-zipped it for rsync. Now we deflate exactly once (-1 = fastest; the
+      # bytes are read once on the far end) and every downstream consumer ships
+      # this same file. Contents sit at the zip root (cd release && zip ./) so
+      # the server entrypoints, which unzip into release/, keep working
+      # unchanged — and so does the deploy-time rsync, which hands this archive
+      # straight to the host action via its release-archive input.
+      - name: Package release into a single zip
+        run: |
+          set -euo pipefail
+          cd release
+          zip -1 -rq "$GITHUB_WORKSPACE/release.zip" ./
+          echo "release.zip: $(du -h "$GITHUB_WORKSPACE/release.zip" | cut -f1)"
+
+      # Upload the single zip as the artifact. It is already compressed, so
+      # store it (compression-level 0 — no pointless re-deflate) and, because it
+      # is one file rather than a tree of thousands, upload-artifact skips the
+      # per-file walk/hash that dominated this step. The deploy job downloads
+      # this same zip and rsyncs it without unpacking.
       - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
           name: release
-          path: release/
+          path: release.zip
           retention-days: 1
           overwrite: true
-          # The release is thousands of small PHP files (every Composer-installed
-          # plugin/theme), and at the default level 6 deflate is the dominant
-          # cost of this step. This artifact lives one day and is consumed
-          # seconds later by the deploy job over GitHub's own network, so trade
-          # CPU for a little bandwidth: level 1 keeps it compressed (transfer
-          # stays small) while cutting the zip time sharply. Drop to 0 (store)
-          # to push upload speed further if the transfer is not the bottleneck.
-          compression-level: 1
+          compression-level: 0
 
       # Archive the deployable zip on the (already-published) GitHub release so
-      # rollbacks/redeploys can download it instead of rebuilding. Publishing is
+      # rollbacks/redeploys can download it instead of rebuilding. This reuses
+      # the zip packaged above — no second compression. Publishing is
       # release-please's job — this workflow no longer drafts or publishes
       # releases (the draft model broke release-please's changelog boundary
       # detection; production now builds its own zip at deploy time, so there is
@@ -226,9 +242,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # -1 (fastest deflate): this is a rollback/redeploy archive, not a
-          # distribution artifact, so max compression buys nothing but burns
-          # CPU over thousands of plugin files.
-          cd release && zip -1 -rq "$GITHUB_WORKSPACE/release.zip" ./ && cd "$GITHUB_WORKSPACE"
           gh release upload "${{ inputs.release_tag }}" release.zip --clobber --repo "${{ github.repository }}"
           echo "::notice::release.zip archived on ${{ inputs.release_tag }} — available for rollback/redeploy"

--- a/.github/workflows/deploy-continue.yml
+++ b/.github/workflows/deploy-continue.yml
@@ -100,12 +100,15 @@ jobs:
             --field environment_url="${{ vars.SITE_URL }}" \
             --field log_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      # Single release.zip from the original run (build.yml packaged it once).
+      # Land it at the workspace root and pass it through — the server entrypoint
+      # is the only place it gets unzipped.
       - name: Download release artifact from run ${{ inputs.workflow_run_id }}
         if: ${{ inputs.release_tag == '' }}
         uses: actions/download-artifact@v8
         with:
           name: release
-          path: release
+          path: .
           run-id: ${{ inputs.workflow_run_id }}
           github-token: ${{ github.token }}
 
@@ -119,10 +122,8 @@ jobs:
           TAG="${{ inputs.release_tag }}"
           REPO="${{ github.repository }}"
           for attempt in $(seq 1 40); do
+            # Leave release.zip at the workspace root for the host action to ship.
             if gh release download "$TAG" --pattern release.zip --repo "$REPO" --clobber 2>/dev/null; then
-              mkdir -p release
-              unzip -oq release.zip -d release
-              rm -f release.zip
               exit 0
             fi
             echo "release.zip not attached to $TAG yet (attempt $attempt/40) — waiting 15s…"
@@ -142,7 +143,7 @@ jobs:
           ssh-host: ${{ secrets.SSH_HOST }}
           ssh-user: ${{ secrets.SSH_USER }}
           ssh-key: ${{ secrets.SSH_KEY }}
-          release-directory: release
+          release-archive: ${{ github.workspace }}/release.zip
           maintenance-mode: ${{ inputs.maintenance_mode }}
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,12 +150,16 @@ jobs:
 
       # When parking for a backup, the release stays in the run's artifact
       # storage (or on the GitHub release) — the continue run fetches it.
+      #
+      # The artifact is a single release.zip (build.yml packaged it once). Land
+      # it at the workspace root and hand it to the host action as-is — no
+      # unpack here; the server entrypoint performs the only unzip.
       - name: Download built release artifact
         if: ${{ inputs.release_tag == '' && !(vars.HOST == 'pressable' && inputs.do_backup) }}
         uses: actions/download-artifact@v8
         with:
           name: release
-          path: release
+          path: .
 
       - name: Download release.zip from release ${{ inputs.release_tag }}
         if: ${{ inputs.release_tag != '' && !(vars.HOST == 'pressable' && inputs.do_backup) }}
@@ -170,11 +174,10 @@ jobs:
           TAG="${{ inputs.release_tag }}"
           REPO="${{ github.repository }}"
           for attempt in $(seq 1 8); do
+            # Leave release.zip at the workspace root: the host action ships it
+            # straight to the server (no unpack here).
             if gh release download "$TAG" --pattern release.zip --repo "$REPO" --clobber 2>/dev/null; then
               echo "::notice::Deploying prebuilt asset from release $TAG — no rebuild needed"
-              mkdir -p release
-              unzip -oq release.zip -d release
-              rm -f release.zip
               exit 0
             fi
             echo "release.zip not on $TAG yet (attempt $attempt/8) — retrying in 15s…"
@@ -244,7 +247,7 @@ jobs:
           ssh-host: ${{ secrets.SSH_HOST }}
           ssh-user: ${{ secrets.SSH_USER }}
           ssh-key: ${{ secrets.SSH_KEY }}
-          release-directory: release
+          release-archive: ${{ github.workspace }}/release.zip
           maintenance-mode: ${{ inputs.maintenance_mode }}
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}
@@ -256,7 +259,7 @@ jobs:
           install-name: ${{ vars.INSTALL_NAME }}
           site-url: ${{ vars.SITE_URL }}
           ssh-key: ${{ secrets.SSH_KEY }}
-          release-directory: release
+          release-archive: ${{ github.workspace }}/release.zip
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}
 
@@ -270,7 +273,7 @@ jobs:
           ssh-key: ${{ secrets.SSH_KEY }}
           ssh-pass: ${{ secrets.SSH_PASS }}
           site-url: ${{ vars.SITE_URL }}
-          release-directory: release
+          release-archive: ${{ github.workspace }}/release.zip
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}
 

--- a/actions/deploy-cloudways/action.yml
+++ b/actions/deploy-cloudways/action.yml
@@ -35,9 +35,13 @@ inputs:
     required: false
     default: ""
   release-directory:
-    description: "Local directory containing the cleaned release"
+    description: "Local directory containing the cleaned release. Ignored when release-archive is set."
     required: false
     default: "release"
+  release-archive:
+    description: "Path to a pre-built release zip (contents at root, e.g. plugins/ and themes/ at the top level). When set, it is shipped to the server as-is instead of re-zipping release-directory — the build job already zipped the release, so this avoids a redundant compression pass."
+    required: false
+    default: ""
   deployment-path:
     description: "Remote staging path for uploaded releases"
     required: false
@@ -93,6 +97,8 @@ runs:
         AUTH_TYPE: ${{ inputs.auth-type }}
         SSH_PASS: ${{ inputs.ssh-pass }}
         DEPLOY_PATH: ${{ inputs.deployment-path }}
+        RELEASE_ARCHIVE: ${{ inputs.release-archive }}
+        RELEASE_DIRECTORY: ${{ inputs.release-directory }}
       run: |
         # One code path for both auth types (v3 duplicated every step)
         if [ "$AUTH_TYPE" = "pass" ]; then
@@ -104,12 +110,18 @@ runs:
         fi
 
         ts="$(date +'%s')"
-        cd "${{ inputs.release-directory }}"
-        zip -rq "$GITHUB_WORKSPACE/$ts.zip" ./
-        cd "$GITHUB_WORKSPACE"
+        # Prefer a pre-built archive (the build job already zipped the release);
+        # otherwise zip the release directory here (-1: the server reads it once).
+        if [ -n "$RELEASE_ARCHIVE" ]; then
+          zip_path="$RELEASE_ARCHIVE"
+        else
+          ( cd "$RELEASE_DIRECTORY" && zip -1 -rq "$GITHUB_WORKSPACE/$ts.zip" ./ )
+          zip_path="$GITHUB_WORKSPACE/$ts.zip"
+        fi
 
         run_remote "mkdir -p $DEPLOY_PATH"
-        copy_remote "$ts.zip" "$DEPLOY_PATH/"
+        # Land it on the server as $ts.zip regardless of the local filename.
+        copy_remote "$zip_path" "$DEPLOY_PATH/$ts.zip"
         run_remote "rm -rf $DEPLOY_PATH/release && unzip -o -q $DEPLOY_PATH/$ts.zip -d $DEPLOY_PATH/release && mkdir -p $DEPLOY_PATH/release/.deployment"
         copy_remote "${{ github.action_path }}/cloudways-entrypoint.sh" "$DEPLOY_PATH/release/.deployment/entrypoint.sh"
         copy_remote "${{ github.action_path }}/maintenance.php" "$DEPLOY_PATH/release/.deployment/maintenance.php"

--- a/actions/deploy-pressable/action.yml
+++ b/actions/deploy-pressable/action.yml
@@ -35,9 +35,13 @@ inputs:
     description: "SSH private key"
     required: true
   release-directory:
-    description: "Local directory containing the cleaned release"
+    description: "Local directory containing the cleaned release. Ignored when release-archive is set."
     required: false
     default: "release"
+  release-archive:
+    description: "Path to a pre-built release zip (contents at root, e.g. plugins/ and themes/ at the top level). When set, it is shipped to the server as-is instead of re-zipping release-directory — the build job already zipped the release, so this avoids a redundant compression pass."
+    required: false
+    default: ""
   deployment-path:
     description: "Remote staging path for uploaded releases"
     required: false
@@ -120,14 +124,23 @@ runs:
     - name: Upload release and entrypoint
       id: upload
       shell: bash
+      env:
+        RELEASE_ARCHIVE: ${{ inputs.release-archive }}
+        RELEASE_DIRECTORY: ${{ inputs.release-directory }}
       run: |
         ts="$(date +'%s')"
         echo "ts=$ts" >> "$GITHUB_OUTPUT"
-        cd "${{ inputs.release-directory }}"
-        zip -rq "$GITHUB_WORKSPACE/$ts.zip" ./
-        cd "$GITHUB_WORKSPACE"
+        # Prefer a pre-built archive (the build job already zipped the release);
+        # otherwise zip the release directory here (-1: the server reads it once).
+        if [ -n "$RELEASE_ARCHIVE" ]; then
+          zip_path="$RELEASE_ARCHIVE"
+        else
+          ( cd "$RELEASE_DIRECTORY" && zip -1 -rq "$GITHUB_WORKSPACE/$ts.zip" ./ )
+          zip_path="$GITHUB_WORKSPACE/$ts.zip"
+        fi
         ssh pressable "mkdir -p ${{ inputs.deployment-path }}/"
-        rsync -e "ssh -p 22" -W "$ts.zip" "pressable:${{ inputs.deployment-path }}/"
+        # Land it on the server as $ts.zip regardless of the local filename.
+        rsync -e "ssh -p 22" -W "$zip_path" "pressable:${{ inputs.deployment-path }}/$ts.zip"
         # v4: the entrypoint ships with this action instead of being wget'd
         # from a branch on the server.
         rsync -e "ssh -p 22" -W "${{ github.action_path }}/pressable-entrypoint.sh" "pressable:${{ inputs.deployment-path }}/entrypoint.sh"

--- a/actions/deploy-wpengine/action.yml
+++ b/actions/deploy-wpengine/action.yml
@@ -23,9 +23,13 @@ inputs:
     description: "SSH private key for the WP Engine SSH gateway"
     required: true
   release-directory:
-    description: "Local directory containing the cleaned release"
+    description: "Local directory containing the cleaned release. Ignored when release-archive is set."
     required: false
     default: "release"
+  release-archive:
+    description: "Path to a pre-built release zip (contents at root, e.g. plugins/ and themes/ at the top level). When set, it is shipped to the server as-is instead of re-zipping release-directory — the build job already zipped the release, so this avoids a redundant compression pass."
+    required: false
+    default: ""
   deployment-path:
     description: "Remote staging path for uploaded releases, relative to the site root"
     required: false
@@ -71,14 +75,22 @@ runs:
       shell: bash
       env:
         REMOTE_BASE: "~/sites/${{ inputs.install-name }}/${{ inputs.deployment-path }}"
+        RELEASE_ARCHIVE: ${{ inputs.release-archive }}
+        RELEASE_DIRECTORY: ${{ inputs.release-directory }}
       run: |
         ts="$(date +'%s')"
         echo "ts=$ts" >> "$GITHUB_OUTPUT"
-        cd "${{ inputs.release-directory }}"
-        zip -rq "$GITHUB_WORKSPACE/$ts.zip" ./
-        cd "$GITHUB_WORKSPACE"
+        # Prefer a pre-built archive (the build job already zipped the release);
+        # otherwise zip the release directory here (-1: the server reads it once).
+        if [ -n "$RELEASE_ARCHIVE" ]; then
+          zip_path="$RELEASE_ARCHIVE"
+        else
+          ( cd "$RELEASE_DIRECTORY" && zip -1 -rq "$GITHUB_WORKSPACE/$ts.zip" ./ )
+          zip_path="$GITHUB_WORKSPACE/$ts.zip"
+        fi
         ssh wpengine "mkdir -p $REMOTE_BASE/"
-        rsync -e "ssh -p 22" -W "$ts.zip" "wpengine:$REMOTE_BASE/"
+        # Land it on the server as $ts.zip regardless of the local filename.
+        rsync -e "ssh -p 22" -W "$zip_path" "wpengine:$REMOTE_BASE/$ts.zip"
         rsync -e "ssh -p 22" -W "${{ github.action_path }}/wpengine-entrypoint.sh" "wpengine:$REMOTE_BASE/entrypoint.sh"
 
     - name: Sync release on the server


### PR DESCRIPTION
Follow-up to #131.

## Why

The release payload is thousands of small files (the root `composer install` materializes every plugin/theme via `composer/installers`), and that payload was being **compressed up to three times** and **transferred as a many-file artifact twice**:

1. `upload-artifact` zips `release/` (per-file walk over thousands of files)
2. the release-attach step zips the same content again
3. each host action re-zips it for rsync
4. deploy pays the many-file artifact transfer on both upload and download

## What changed — zip once, unzip once

The build job now produces **one `release.zip`** and that same file flows all the way to the server, which does the only unzip.

| File | Change |
|---|---|
| `build.yml` | New "Package release into a single zip" step (`zip -1`, contents at root). Artifact is now that single file at `compression-level: 0` (already compressed → no re-deflate, and one file skips the per-file walk). The release-attach step **reuses** the same zip instead of re-zipping. |
| `deploy.yml`, `deploy-continue.yml` | Download `release.zip` and pass it straight to the host action — **no runner-side unpack**, on both the artifact path and the rollback release-asset path. |
| `deploy-pressable`, `deploy-wpengine`, `deploy-cloudways` | New optional `release-archive` input. When set, the prebuilt zip is rsynced to the server as `<ts>.zip` with no local re-zip. When **unset**, they fall back to zipping `release-directory` (now `-1`). |

## Backward compatibility

- Artifact name (`release`) unchanged.
- Server-side contract unchanged: contents at the zip root, entrypoints unzip into `release/`.
- `release-archive` is optional and additive — any repo calling `deploy-*@v4` directly with only `release-directory` keeps working via the fallback branch (which exercises the *same* code path the Pressable test covers).

## Expected impact

Eliminates the two slowest measured build-job steps' redundancy (artifact upload ~49s + release attach ~21s) and the deploy-side artifact download/unpack, plus the host re-zip. Stacks on top of #131.

## Testing

- [ ] Pressable production deploy (release-triggered, `build_for_release`) — primary path, will be exercised on the next `linchpin.com` release.
- [ ] Pressable rollback (`release_tag`) — release-asset pass-through.
- WP Engine / Cloudways use the identical pass-through pattern (only the `<ts>.zip` source changes; remote unzip is untouched) but aren't exercised by linchpin.com — flagging for those clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)