### PR TITLE
feat(LINCHPIN-4917): Add auto-merge for non-major renovate PRs into maintenance branches

### DIFF
--- a/.github/workflows/auto-approve-maintenance.yml
+++ b/.github/workflows/auto-approve-maintenance.yml
@@ -10,7 +10,10 @@ jobs:
   auto-approve:
     runs-on: ubuntu-latest
 
-    if: startsWith(github.head_ref, 'maintenance/') || startsWith(github.head_ref, 'security-update/')
+    if: >-
+      startsWith(github.head_ref, 'maintenance/') ||
+      startsWith(github.head_ref, 'security-update/') ||
+      startsWith(github.base_ref, 'maintenance/')
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/auto-merge-maintenance.yml
+++ b/.github/workflows/auto-merge-maintenance.yml
@@ -1,0 +1,99 @@
+name: Auto Merge Maintenance PRs
+
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        description: "Log what would be merged without merging anything"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GH_BOT_TOKEN:
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto merge eligible Renovate PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find and merge eligible Renovate PRs
+        env:
+          GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Same allow-list auto-approve-maintenance.yml uses — kept in sync
+          # manually since each workflow is a standalone workflow_call file.
+          allowed_files_regex="(\.github/workflows/.*\.ya?ml|\.release-please-manifest\.json|release-please-config\.json|CHANGELOG\.md|README\.md|\.gitignore|\.distignore|\.editorconfig|\.php-cs-fixer\.dist\.php|\.phplint\.yml|\.vipgoci_lint_skip_folders|\.vipgoci_phpcs_skip_folders|commitlint\.config\.js|dependabot\.yml|renovate\.json|pantheon\.yml|phpcs\.xml|composer\.json|composer\.lock|package\.json|package-lock\.json|yarn\.lock|themes/.*/style\.css|themes/.*/functions\.php|plugins/.+-functionality/.+-functionality\.php)$"
+
+          # Monthly maintenance branches only — this is the hard guard that
+          # keeps this workflow from ever touching main/master.
+          base_branch_regex='^maintenance/[0-9]{4}-[0-9]{2}$'
+
+          prs=$(gh pr list --state open --limit 100 \
+            --json number,baseRefName,author,labels,files,mergeStateStatus)
+
+          echo "$prs" | jq -c '.[]' | while IFS= read -r pr; do
+            number=$(jq -r '.number' <<< "$pr")
+            base=$(jq -r '.baseRefName' <<< "$pr")
+            author=$(jq -r '.author.login' <<< "$pr")
+            merge_state=$(jq -r '.mergeStateStatus' <<< "$pr")
+            labels=$(jq -r '[.labels[].name] | join(",")' <<< "$pr")
+            files=$(jq -r '.files[].path' <<< "$pr")
+
+            echo "::group::PR #$number ($base, author: $author)"
+
+            if [[ ! "$base" =~ $base_branch_regex ]]; then
+              echo "skip: base branch '$base' is not a maintenance/YYYY-MM branch"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [[ "$author" != "renovate[bot]" ]]; then
+              echo "skip: author '$author' is not renovate[bot]"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [[ ",$labels," == *",major,"* ]]; then
+              echo "skip: labeled 'major'"
+              echo "::endgroup::"
+              continue
+            fi
+
+            invalid=0
+            while IFS= read -r file; do
+              [[ -z "$file" ]] && continue
+              if [[ ! "$file" =~ $allowed_files_regex ]]; then
+                echo "skip: changed file '$file' is outside the allow-list"
+                invalid=1
+              fi
+            done <<< "$files"
+
+            if [[ "$invalid" -eq 1 ]]; then
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [[ "$merge_state" != "CLEAN" ]]; then
+              echo "skip: mergeStateStatus is '$merge_state', not CLEAN yet — will retry next run"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "dry-run: would merge PR #$number"
+            else
+              echo "merging PR #$number"
+              gh pr merge "$number" --squash
+            fi
+
+            echo "::endgroup::"
+          done

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Linchpin WordPress projects use [Release Please](https://github.com/googleapis/r
 | [deploy-continue.yml](.github/workflows/deploy-continue.yml) | Second half of the backup-and-continue flow — dispatched (via the caller) by Mantle once the Pressable backup completes |
 | [lint.yml](.github/workflows/lint.yml)                     | PR lint: PHP syntax (any version), phpcs on changed files via cs2pr, optional PHPStan                          |
 | [update-readme.yml](.github/workflows/update-readme.yml)   | Update the project README plugin table from composer.lock                                                      |
+| [auto-approve-maintenance.yml](.github/workflows/auto-approve-maintenance.yml) | Auto-approve PRs into a `maintenance/*` branch (or from a `security-update/*` branch) when only allow-listed dependency/config files changed |
+| [auto-merge-maintenance.yml](.github/workflows/auto-merge-maintenance.yml) | Cron-driven: auto-merges open Renovate PRs targeting a `maintenance/YYYY-MM` branch, excluding anything labeled `major`. Never touches main/master |
 | [ci.yml](.github/workflows/ci.yml)                         | This repo's own CI: actionlint + yamllint + zizmor                                                             |
 
 ### Composite Actions
@@ -138,6 +140,31 @@ jobs:
       environment: production
       # Build this release, deploy it, and archive the zip on the release.
       build_for_release: ${{ github.event.release.tag_name }}
+```
+
+To auto-merge non-major Renovate PRs into a monthly `maintenance/YYYY-MM`
+branch, add a caller workflow with its own `schedule` trigger (schedules
+only fire in the repo where they're defined, so this small wrapper has to
+live in the client repo — `auto-merge-maintenance.yml` itself only reacts
+to `workflow_call`):
+
+```yaml
+name: Auto-merge Maintenance PRs
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+
+jobs:
+  auto-merge:
+    uses: linchpin/actions/.github/workflows/auto-merge-maintenance.yml@v4
+    secrets: inherit
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
 ```
 
 ## Renovate Bot Scanning Configurations

--- a/global.json
+++ b/global.json
@@ -32,6 +32,10 @@
         "npm",
         "github-actions"
       ]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "labels": ["major"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `auto-merge-maintenance.yml`, a `workflow_call` reusable workflow that merges open
  Renovate PRs targeting a `maintenance/YYYY-MM` base branch once checks are clean, skipping
  anything labeled `major` and anything touching files outside the existing maintenance
  allow-list. Only ever queries `maintenance/*` base branches, so it structurally cannot
  touch `main`/`master`.
- Tags major Renovate updates with a `major` label via `global.json` so the workflow can
  filter on it.
- Extends `auto-approve-maintenance.yml` to also approve PRs whose **base** (not just head)
  branch is a maintenance branch, since branch protection may require approval before merge.
- Documents both workflows + a caller-repo usage snippet in `README.md`.

## Test plan
- [x] `global.json` is valid JSON; both workflow files are valid YAML; embedded bash passes `bash -n`
- [x] Manually checked line lengths against `.ymllint.yml`'s 125-char limit
- [ ] CI (`ci.yml`: actionlint + yamllint + zizmor) green on this PR
- [ ] Pilot with `dry_run: true` on a client repo with an active `maintenance/YYYY-MM` branch and open Renovate PRs before enabling live merging

Linked ClickUp task: https://app.clickup.com/t/86b8tk9cg (LINCHPIN-4917)