### PR TITLE
feat(NO-TASK): symlink-aware deploys and remote Composer plugin install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,12 +89,23 @@ jobs:
       # though `composer install` correctly tolerates it (warns, succeeds). The
       # PR-time gate (validate-composer.yml) uses `composer install` for the
       # same reason.
+      # This step is unconditional on purpose. It used to carry
+      # `if: vars.REMOTE_PLUGIN_INSTALL == 'false'`, which skipped PHP setup and
+      # the root Composer install for every repo that had simply never defined the
+      # variable ('' != 'false') — the documented default is false, so the common
+      # case silently built with no dependencies installed and whatever PHP the
+      # runner image happened to ship. PHP is now always pinned and the Composer
+      # cache always warmed; only the install itself is conditional, via the
+      # action's `install` input.
       - name: Setup PHP and install project Composer dependencies
-        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'false' }}
         uses: linchpin/actions/actions/setup-wp-php@v4
         with:
           php-version: ${{ inputs.php_version || vars.PHP_VERSION }}
           composer-auth: ${{ secrets.PACKAGIST_COMPOSER_AUTH_JSON }}
+          # Remote plugin install resolves third-party packages on the server from
+          # composer.lock, so installing them here would only be excluded from the
+          # release again by build-release.
+          install: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' && 'false' || 'true' }}
 
       - name: Setup Node.js (npm cache)
         if: ${{ hashFiles('themes/*/package-lock.json', 'plugins/*/package-lock.json', 'plugins/*/blocks/package-lock.json') != '' }}

--- a/.github/workflows/deploy-continue.yml
+++ b/.github/workflows/deploy-continue.yml
@@ -61,6 +61,22 @@ on:
         required: false
         default: true
         type: boolean
+      protected_paths:
+        description: >-
+          Paths this deploy must never overwrite, relative to wp-content
+          (one per line, comma separated, or a JSON array; globs allowed).
+          Defaults to vars.PROTECTED_PATHS.
+        required: false
+        default: ""
+        type: string
+      preserve_symlinks:
+        description: >-
+          Leave plugins/themes/mu-plugins that are symlinks on the server exactly
+          as they are (Pressable links platform-owned plugins such as jetpack and
+          woocommerce into wp-content).
+        required: false
+        default: true
+        type: boolean
     secrets:
       PRESSABLE_API_CLIENT_ID:
         required: false
@@ -71,6 +87,12 @@ on:
       SSH_USER:
         required: false
       SSH_KEY:
+        required: false
+      SATISPRESS_USER:
+        description: "Private Packagist username, used only by the REMOTE_PLUGIN_INSTALL reconcile"
+        required: false
+      SATISPRESS_PASSWORD:
+        description: "Private Packagist password, used only by the REMOTE_PLUGIN_INSTALL reconcile"
         required: false
 
 jobs:
@@ -147,12 +169,40 @@ jobs:
           maintenance-mode: ${{ inputs.maintenance_mode }}
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
 
       - name: Unsupported host
         if: ${{ vars.HOST != 'pressable' }}
         run: |
           echo "::error::The backup-and-continue flow currently supports HOST=pressable only (the backup is a Pressable API feature)"
           exit 1
+
+      # Mirrors deploy.yml: without this, a do_backup deploy would finish here
+      # having synced only the project's own code and never reconciled the
+      # Composer-managed packages, while still reporting success.
+      - name: Extract composer.lock from the release
+        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' }}
+        run: |
+          if ! unzip -o -q "${{ github.workspace }}/release.zip" composer.lock -d "${{ github.workspace }}"; then
+            echo "::error::composer.lock is not in release.zip."
+            echo "REMOTE_PLUGIN_INSTALL needs it — check that the project .distignore does not exclude it."
+            exit 1
+          fi
+
+      - name: Remote plugin install
+        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' }}
+        uses: linchpin/actions/actions/remote-plugin-install@v4
+        with:
+          ssh-host: ${{ secrets.SSH_HOST }}
+          ssh-user: ${{ secrets.SSH_USER }}
+          ssh-key: ${{ secrets.SSH_KEY }}
+          wp-path: /srv/htdocs
+          composer-lock: ${{ github.workspace }}/composer.lock
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
+          package-auth-user: ${{ secrets.SATISPRESS_USER }}
+          package-auth-password: ${{ secrets.SATISPRESS_PASSWORD }}
 
       - name: Mark deployment successful
         if: ${{ success() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,25 @@ on:
         required: false
         default: true
         type: boolean
+      protected_paths:
+        description: >-
+          Paths this deploy must never overwrite, relative to wp-content
+          (one per line, comma separated, or a JSON array; globs allowed).
+          Defaults to vars.PROTECTED_PATHS. Symlinks on the server are already
+          skipped automatically — this is for paths that are still real folders
+          but are managed outside the repo.
+        required: false
+        default: ""
+        type: string
+      preserve_symlinks:
+        description: >-
+          Leave plugins/themes/mu-plugins that are symlinks on the server exactly
+          as they are (managed hosts link platform-owned plugins such as jetpack
+          and woocommerce into wp-content). Set false only to let a deploy
+          replace symlinks with real directories.
+        required: false
+        default: true
+        type: boolean
     secrets:
       PACKAGIST_COMPOSER_AUTH_JSON:
         required: false
@@ -92,6 +111,12 @@ on:
       SSH_PASS:
         required: false
       MANTLE_API_BEARER:
+        required: false
+      SATISPRESS_USER:
+        description: "Private Packagist username, used only by the REMOTE_PLUGIN_INSTALL reconcile"
+        required: false
+      SATISPRESS_PASSWORD:
+        description: "Private Packagist password, used only by the REMOTE_PLUGIN_INSTALL reconcile"
         required: false
 
 jobs:
@@ -251,6 +276,8 @@ jobs:
           maintenance-mode: ${{ inputs.maintenance_mode }}
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
 
       - name: Deploy to WP Engine
         if: ${{ vars.HOST == 'wpengine' }}
@@ -262,6 +289,8 @@ jobs:
           release-archive: ${{ github.workspace }}/release.zip
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
 
       - name: Deploy to Cloudways
         if: ${{ vars.HOST == 'cloudways' }}
@@ -276,12 +305,82 @@ jobs:
           release-archive: ${{ github.workspace }}/release.zip
           post-deploy-command: ${{ inputs.post_deploy_command }}
           health-check: ${{ inputs.health_check }}
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
 
       - name: Unsupported host
         if: ${{ !contains(fromJSON('["pressable","wpengine","cloudways"]'), vars.HOST) }}
         run: |
           echo "::error::HOST='${{ vars.HOST }}' is not supported by linchpin/actions v4 (expected pressable, wpengine, or cloudways)"
           exit 1
+
+      # Remote plugin install (vars.REMOTE_PLUGIN_INSTALL). The release that just
+      # landed carries only the project's own code; third-party plugins and themes
+      # are reconciled here from composer.lock, one short WP-CLI call per package.
+      # The lock travels inside release.zip, so this works identically for a fresh
+      # build and for a release_tag rollback — and because the lock is the source
+      # of truth in both directions, a rollback downgrades plugins rather than
+      # leaving them ahead of the code.
+      # Cloudways Autonomous authenticates with a password, and remote-plugin-install
+      # only does key auth. Fail before the reconcile rather than skipping it and
+      # reporting a successful deploy that shipped no third-party plugins.
+      - name: Remote plugin install unsupported for this auth type
+        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' && vars.HOST == 'cloudways' && vars.DEPLOYMENT_AUTH_TYPE == 'pass' }}
+        run: |
+          echo "::error::REMOTE_PLUGIN_INSTALL is not supported with DEPLOYMENT_AUTH_TYPE=pass (password SSH)."
+          echo "Use key auth, or unset REMOTE_PLUGIN_INSTALL."
+          exit 1
+
+      - name: Extract composer.lock from the release
+        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' }}
+        run: |
+          if ! unzip -o -q "${{ github.workspace }}/release.zip" composer.lock -d "${{ github.workspace }}"; then
+            echo "::error::composer.lock is not in release.zip."
+            echo "REMOTE_PLUGIN_INSTALL needs it — check that the project .distignore does not exclude it."
+            exit 1
+          fi
+
+      - name: Remote plugin install (Pressable)
+        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' && vars.HOST == 'pressable' }}
+        uses: linchpin/actions/actions/remote-plugin-install@v4
+        with:
+          ssh-host: ${{ secrets.SSH_HOST }}
+          ssh-user: ${{ secrets.SSH_USER }}
+          ssh-key: ${{ secrets.SSH_KEY }}
+          wp-path: /srv/htdocs
+          composer-lock: ${{ github.workspace }}/composer.lock
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
+          package-auth-user: ${{ secrets.SATISPRESS_USER }}
+          package-auth-password: ${{ secrets.SATISPRESS_PASSWORD }}
+
+      - name: Remote plugin install (WP Engine)
+        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' && vars.HOST == 'wpengine' }}
+        uses: linchpin/actions/actions/remote-plugin-install@v4
+        with:
+          ssh-host: ${{ vars.INSTALL_NAME }}.ssh.wpengine.net
+          ssh-user: ${{ vars.INSTALL_NAME }}
+          ssh-key: ${{ secrets.SSH_KEY }}
+          wp-path: ~/sites/${{ vars.INSTALL_NAME }}
+          composer-lock: ${{ github.workspace }}/composer.lock
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
+          package-auth-user: ${{ secrets.SATISPRESS_USER }}
+          package-auth-password: ${{ secrets.SATISPRESS_PASSWORD }}
+
+      - name: Remote plugin install (Cloudways)
+        if: ${{ vars.REMOTE_PLUGIN_INSTALL == 'true' && vars.HOST == 'cloudways' && vars.DEPLOYMENT_AUTH_TYPE != 'pass' }}
+        uses: linchpin/actions/actions/remote-plugin-install@v4
+        with:
+          ssh-host: ${{ secrets.SSH_HOST }}
+          ssh-user: ${{ secrets.SSH_USER }}
+          ssh-key: ${{ secrets.SSH_KEY }}
+          wp-path: ~/public_html
+          composer-lock: ${{ github.workspace }}/composer.lock
+          protected-paths: ${{ inputs.protected_paths || vars.PROTECTED_PATHS }}
+          preserve-symlinks: ${{ inputs.preserve_symlinks }}
+          package-auth-user: ${{ secrets.SATISPRESS_USER }}
+          package-auth-password: ${{ secrets.SATISPRESS_PASSWORD }}
 
       # When the deploy is parked for a backup, the deployment stays `queued`
       # and the continue workflow is responsible for the final status.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The headlines:
 - **Deploys verify themselves.** A post-deploy health check gates the GitHub
   deployment status; maintenance mode is opt-in; bookkeeping jobs became
   steps.
+- **Symlinked folders are left alone.** Plugins a managed host serves from its
+  own storage (Pressable links `jetpack` and `woocommerce` into `wp-content`) are
+  detected and skipped instead of being rsynced over, and a project can declare
+  additional off-limits paths with `PROTECTED_PATHS`. See
+  [Symlinked and host-managed folders](#symlinked-and-host-managed-folders).
 - **Least-privilege permissions** declared in every workflow, and secrets are
   passed via env (no auth.json on disk).
 
@@ -59,8 +64,8 @@ To learn more [about secrets](https://docs.github.com/en/actions/security-for-gi
 | PRESSABLE_API_CLIENT_SECRET  |         | Pressable API secret                                                                    |
 | MANTLE_API_BEARER            |         | Mantle API token used by the backup-and-continue deploy flow                            |
 | GH_BOT_TOKEN                 |         | Bot token used by update-readme.yml to open PRs                                         |
-| SATISPRESS_USER              |         | Private Packagist auth (remote-plugin-install path — not yet ported to v4)              |
-| SATISPRESS_PASSWORD          |         | Private Packagist auth (remote-plugin-install path — not yet ported to v4)              |
+| SATISPRESS_USER              |         | Private Packagist auth, used only by the `REMOTE_PLUGIN_INSTALL` reconcile               |
+| SATISPRESS_PASSWORD          |         | Private Packagist auth, used only by the `REMOTE_PLUGIN_INSTALL` reconcile               |
 
 ### Variables
 
@@ -73,7 +78,7 @@ To learn more [about variables](https://docs.github.com/en/actions/writing-workf
 | SITE_ID               |         | When using **Pressable** this is how we reference a site                                 |
 | INSTALL_NAME          |         | Install name when project is hosted on WP Engine                                         |
 | DEPLOYMENT_AUTH_TYPE  | key     | Cloudways SSH auth type: `key` or `pass` (Cloudways Autonomous)                          |
-| REMOTE_PLUGIN_INSTALL | false   | Install plugins on the server via WP CLI instead of shipping them (not yet ported to v4) |
+| REMOTE_PLUGIN_INSTALL | false   | Install third-party plugins/themes on the server from `composer.lock` via WP-CLI instead of shipping them — see [below](#remote-plugin-install-composer-on-the-server) |
 | BRANCH                | staging | The default branch associated with the environment                                       |
 | PHP_VERSION           |         | PHP version used for builds and linting (e.g. `8.5`)                                     |
 | NODE_VERSION          |         | Node version used for builds (e.g. `24`)                                                 |
@@ -81,10 +86,118 @@ To learn more [about variables](https://docs.github.com/en/actions/writing-workf
 | PLUGINS               |         | A JSON formatted array of plugins to build Ex `["linchpin-functionality"]`               |
 | THEME_USES_COMPOSER   | false   | Do the theme(s) use composer to load dependencies                                        |
 | PLUGIN_USES_COMPOSER  | true    | Do the plugin(s) use composer to load dependencies                                       |
+| PROTECTED_PATHS       |         | Paths a deploy must never overwrite, relative to `wp-content` — see [below](#symlinked-and-host-managed-folders) |
 
 > v3's `ENVIRONMENT` and `DEPLOYMENT_PATH` variables are no longer read by
 > v4 workflows (deployment paths are composite-action inputs with per-host
 > defaults).
+
+## Symlinked and host-managed folders
+
+Managed hosts serve some plugins from platform-owned storage and link them into
+the site — on Pressable, `jetpack` and `woocommerce` are usually symlinks inside
+`wp-content/plugins` rather than real folders. Syncing a release copy onto such a
+path is destructive either way: rsync follows the link and writes **through** it
+(so `--delete` prunes files the platform owns), or the link is replaced by a real
+directory and the site silently stops receiving platform updates.
+
+**v4 deploys detect this and leave it alone.** Before syncing, the server-side
+entrypoint scans `wp-content` and skips anything that is a symlink:
+
+- `plugins/` and `themes/` are synced one folder at a time, so a symlinked child
+  is skipped whole.
+- `mu-plugins/` is synced as a tree, so symlinked entries become rsync
+  `--exclude` rules — without that, `--delete` would remove the host's own
+  mu-plugins.
+- Every symlink found is printed at the top of the sync log with its target, and
+  everything skipped is listed again in a closing summary. A path the release
+  actually ships but that was not deployed is annotated as a warning, so it can't
+  quietly go missing.
+
+Nothing needs configuring for that — it is on by default. Set `PROTECTED_PATHS`
+when a path is a **real folder today** but is still managed outside the repo
+(a client installs it from WP admin, another pipeline owns it, a vendor ships it
+directly):
+
+```
+# Repo or environment variable — any of these forms work
+PROTECTED_PATHS = plugins/some-client-managed-plugin, plugins/woocommerce*
+PROTECTED_PATHS = ["plugins/some-client-managed-plugin", "themes/legacy"]
+PROTECTED_PATHS = plugins/some-client-managed-plugin
+                  themes/legacy
+```
+
+Paths are relative to `wp-content`, globs are allowed, and a bare name (no
+slash) matches that folder wherever it lives — `woocommerce` covers
+`plugins/woocommerce`. `#` starts a comment.
+
+A single deploy can override the variable with the `protected_paths` input, and
+`preserve_symlinks: false` turns the automatic symlink detection off (only useful
+when a deploy is *meant* to replace symlinks with real directories). On
+Pressable, `plugins/jetpack` and `plugins/akismet` are always protected — v3
+deleted them from the release; v4 keeps them out of the sync and says so in the
+log.
+
+## Remote plugin install (Composer on the server)
+
+By default a deploy ships everything: the build resolves Composer, and the release
+zip carries every third-party plugin and theme. `REMOTE_PLUGIN_INSTALL=true`
+inverts that for the Composer-managed part — the release contains only the
+project's own code plus `composer.json`/`composer.lock`, and after the sync the
+deploy reconciles the server against the lock with one WP-CLI call per package.
+
+**What actually gets faster.** Not the build — set expectations here. Composer was
+never the slow part (its cache is keyed on `composer.lock`); npm theme/plugin
+builds dominate, and those still run on the runner because Pressable has no Node.
+What shrinks is everything downstream of the build: the release zip, the transfer,
+the GitHub release asset kept for rollbacks, the two-zip retention on the server,
+and the sync itself — a Renovate bump of one plugin becomes one `wp plugin install`
+instead of re-rsyncing the whole tree.
+
+**Why not `composer install` over SSH.** Pressable's Composer guide documents an
+"SSH build" that runs `composer install` in the container. This repo deliberately
+does not do that: managed containers cap a single exec at ~300s (Pressable's own
+troubleshooting table lists *"CLI job killed around 300 s — container exec
+timeout"*), which a cold Composer install for a WooCommerce-scale project does not
+reliably fit inside — and it would die mid-write with maintenance mode already on.
+One short WP-CLI call per package stays far inside the cap, keeps Composer and
+registry credentials off the server entirely, and leaves resolution on the runner.
+
+**The lock is the source of truth, in both directions.** A package whose installed
+version differs from the lock is reinstalled *at the locked version*, so deploying
+an older `release_tag` downgrades third-party plugins instead of leaving them ahead
+of the code. (v3 compared with `version_compare` and only ever upgraded, which
+silently made rollbacks a no-op for everything Composer managed.)
+
+**It respects `PROTECTED_PATHS` and symlinks.** Composer's `installer-paths` would
+happily delete a platform symlink and drop a real directory in its place, and
+WP-CLI would too — so every package is checked against the server's symlinks and
+your protected paths before anything is installed. Note the skeleton in Pressable's
+guide lists `wpackagist-plugin/woocommerce` in `require`; on a site where Pressable
+symlinks WooCommerce, that package is skipped and logged rather than fighting the
+platform.
+
+```
+REMOTE_PLUGIN_INSTALL = true
+SATISPRESS_USER / SATISPRESS_PASSWORD   # only if you pull from packagist.linchpin.com
+```
+
+Requirements and caveats:
+
+- **Per-plugin autoloaders only.** This mode skips the root Composer install, so
+  there is no root `vendor/` in the release and nothing creates one on the server.
+  That matches the layout Pressable's guide recommends (each plugin requires its
+  own `vendor/autoload.php`). A project that depends on a *root* autoloader should
+  not enable it.
+- **Packages need a dist archive.** A source-only requirement (typically a `dev-*`
+  VCS branch) has no zip for WP-CLI to install, so `build-release` keeps those in
+  the release and they arrive over rsync as before. This is automatic.
+- **New packages install inactive.** Nothing is activated for you — the run logs a
+  warning listing them; activate via `post_deploy_command: wp plugin activate <slug>`.
+- **Consider `maintenance_mode: true`.** `wp plugin install --force` replaces a
+  plugin directory in place, so an updated plugin is briefly absent.
+- **Key auth only.** Cloudways Autonomous (`DEPLOYMENT_AUTH_TYPE=pass`) is not
+  supported and the deploy fails loudly rather than skipping the reconcile.
 
 ## GitHub Reusable Workflows
 
@@ -105,9 +218,10 @@ Linchpin WordPress projects use [Release Please](https://github.com/googleapis/r
 | ----------------------------------------------- | --------------------------------------------------------------------------------- |
 | [setup-wp-php](actions/setup-wp-php)            | PHP via setup-php + cached Composer install + COMPOSER_AUTH (no auth.json on disk) |
 | [build-release](actions/build-release)          | Turn a built tree into a clean release/ dir using the project .distignore          |
-| [deploy-pressable](actions/deploy-pressable)    | Upload + sync a release to Pressable over SSH, maintenance mode, health check      |
-| [deploy-wpengine](actions/deploy-wpengine)      | Upload + sync a release to WP Engine over SSH, health check                        |
-| [deploy-cloudways](actions/deploy-cloudways)    | Upload + sync a release to Cloudways (key or password SSH auth), health check      |
+| [deploy-pressable](actions/deploy-pressable)    | Upload + symlink-aware sync of a release to Pressable over SSH, maintenance mode, health check |
+| [deploy-wpengine](actions/deploy-wpengine)      | Upload + symlink-aware sync of a release to WP Engine over SSH, health check       |
+| [deploy-cloudways](actions/deploy-cloudways)    | Upload + symlink-aware sync of a release to Cloudways (key or password SSH auth), health check |
+| [remote-plugin-install](actions/remote-plugin-install) | Reconcile third-party plugins/themes against composer.lock with per-package WP-CLI calls over SSH |
 | [update-readme](actions/update-readme)          | Regenerate the README plugin/theme table from composer.lock                        |
 
 ## Example Shared Workflow Usage

--- a/actions/build-release/cleanup.sh
+++ b/actions/build-release/cleanup.sh
@@ -28,11 +28,49 @@ fi
 EXCLUDES="$(mktemp)"
 cp "$DISTIGNORE" "$EXCLUDES"
 
-# When installing plugins remotely the server needs the composer files,
-# so remove them from the exclude list.
+# Remote plugin install: the server resolves third-party plugins and themes from
+# composer.lock itself (see actions/remote-plugin-install), so the lock has to
+# ship and the packages it covers must not. Dropping them is where this mode pays
+# for itself — vendor-installed plugins are the bulk of a release, and a release
+# that carries only the project's own code transfers, stores and syncs in a
+# fraction of the time.
 if [ "$REMOTE_PLUGIN_INSTALL" = "true" ]; then
   echo "Keeping composer.json/composer.lock in the release for remote plugin install"
   sed -i '/composer.json\|composer.lock/d' "$EXCLUDES"
+
+  LOCK="$SRC/composer.lock"
+  if [ ! -f "$LOCK" ]; then
+    echo "::error::REMOTE_PLUGIN_INSTALL is true but no composer.lock was found at $LOCK"
+    exit 1
+  fi
+
+  # Only packages that actually have a dist archive: WP-CLI installs from a zip
+  # URL, so a source-only requirement (typically a dev-* VCS branch) has nothing
+  # to install from and must keep travelling in the release instead.
+  excluded_packages=0
+  while IFS=$'\t' read -r name type; do
+    slug="${name##*/}"
+    case "$type" in
+      wordpress-plugin) printf '/plugins/%s/\n' "$slug" >> "$EXCLUDES" ;;
+      wordpress-theme) printf '/themes/%s/\n' "$slug" >> "$EXCLUDES" ;;
+      *) continue ;;
+    esac
+    excluded_packages=$((excluded_packages + 1))
+  done < <(jq -r '
+    .packages[]
+    | select((.type == "wordpress-plugin" or .type == "wordpress-theme")
+             and (.dist.url // "") != "")
+    | [.name, .type]
+    | @tsv
+  ' "$LOCK")
+
+  echo "Excluding $excluded_packages Composer-managed package(s) — the server installs these from composer.lock"
+
+  # Note: this mode does not run the root Composer install on the runner either,
+  # so there is no root vendor/ to ship and nothing creates one on the server.
+  # It suits the per-plugin autoloader layout Pressable's Composer guide
+  # recommends (each plugin requires its own vendor/autoload.php); a project that
+  # depends on a ROOT autoloader should not use REMOTE_PLUGIN_INSTALL.
 fi
 
 # Never ship these, regardless of what the project .distignore says.

--- a/actions/deploy-cloudways/action.yml
+++ b/actions/deploy-cloudways/action.yml
@@ -46,6 +46,14 @@ inputs:
     description: "Remote staging path for uploaded releases"
     required: false
     default: "~/private_html/releases"
+  protected-paths:
+    description: "Paths this deploy must never overwrite, relative to wp-content — one per line, comma separated, or a JSON array. Globs are allowed (e.g. `plugins/woocommerce*`), and a bare name matches that folder in any of plugins/themes/mu-plugins. Anything that is a symlink on the server is skipped automatically; use this for paths that are still real folders but are managed outside the repo."
+    required: false
+    default: ""
+  preserve-symlinks:
+    description: "Leave any plugin/theme/mu-plugin that is a symlink on the server exactly as it is instead of syncing over it (true/false). Without this, rsync writes through the link into whatever storage the platform manages, or --delete prunes files the platform owns. Only set this to false if a deploy is meant to replace symlinks with real directories."
+    required: false
+    default: "true"
   post-deploy-command:
     description: "Optional shell command(s) run on the server after the sync"
     required: false
@@ -90,6 +98,43 @@ runs:
         END
         fi
 
+    # Normalise the protection config here, on the runner, so the server-side
+    # entrypoint reads a plain one-path-per-line file — nothing project-supplied
+    # is ever interpolated into a remote shell command.
+    - name: Resolve symlink protection
+      id: protection
+      shell: bash
+      env:
+        PROTECTED_PATHS: ${{ inputs.protected-paths }}
+        PRESERVE_SYMLINKS: ${{ inputs.preserve-symlinks }}
+      run: |
+        list="$RUNNER_TEMP/protected-paths.txt"
+        : > "$list" # always written, so a stale file from a prior deploy is replaced
+        if [ -n "$PROTECTED_PATHS" ]; then
+          # Accept a JSON array (matching the THEMES/PLUGINS convention) or a
+          # comma/newline separated list.
+          if printf '%s' "$PROTECTED_PATHS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            printf '%s' "$PROTECTED_PATHS" | jq -r '.[]' >> "$list"
+          else
+            printf '%s\n' "$PROTECTED_PATHS" | tr ',' '\n' >> "$list"
+          fi
+          # Trim whitespace, wrapping quotes and leading/trailing slashes, then
+          # drop comments and blanks. Paths reach the server as bare
+          # wp-content-relative globs.
+          sed -i -e 's#^[[:space:]"/]*##' -e 's#[[:space:]"/]*$##' -e '/^#/d' -e '/^$/d' "$list"
+        fi
+        # Narrowed to a literal true/false before it reaches the ssh command line.
+        case "$PRESERVE_SYMLINKS" in
+          false|False|FALSE|0|no|No|NO) preserve=false ;;
+          *) preserve=true ;;
+        esac
+        echo "preserve=$preserve" >> "$GITHUB_OUTPUT"
+        echo "Preserve server symlinks: $preserve"
+        if [ -s "$list" ]; then
+          echo "Protected paths (never overwritten on the server):"
+          sed 's/^/  • /' "$list"
+        fi
+
     - name: Upload release and scripts, sync on the server
       id: deploy
       shell: bash
@@ -99,6 +144,7 @@ runs:
         DEPLOY_PATH: ${{ inputs.deployment-path }}
         RELEASE_ARCHIVE: ${{ inputs.release-archive }}
         RELEASE_DIRECTORY: ${{ inputs.release-directory }}
+        PRESERVE_SYMLINKS: ${{ steps.protection.outputs.preserve }}
       run: |
         # One code path for both auth types (v3 duplicated every step)
         if [ "$AUTH_TYPE" = "pass" ]; then
@@ -125,7 +171,8 @@ runs:
         run_remote "rm -rf $DEPLOY_PATH/release && unzip -o -q $DEPLOY_PATH/$ts.zip -d $DEPLOY_PATH/release && mkdir -p $DEPLOY_PATH/release/.deployment"
         copy_remote "${{ github.action_path }}/cloudways-entrypoint.sh" "$DEPLOY_PATH/release/.deployment/entrypoint.sh"
         copy_remote "${{ github.action_path }}/maintenance.php" "$DEPLOY_PATH/release/.deployment/maintenance.php"
-        run_remote "cd $DEPLOY_PATH/release/.deployment && chmod +x ./entrypoint.sh && bash ./entrypoint.sh"
+        copy_remote "$RUNNER_TEMP/protected-paths.txt" "$DEPLOY_PATH/release/.deployment/protected-paths.txt"
+        run_remote "cd $DEPLOY_PATH/release/.deployment && chmod +x ./entrypoint.sh && PRESERVE_SYMLINKS=$PRESERVE_SYMLINKS bash ./entrypoint.sh"
 
         if [ -n "${{ inputs.post-deploy-command }}" ]; then
           run_remote "${{ inputs.post-deploy-command }}"

--- a/actions/deploy-cloudways/cloudways-entrypoint.sh
+++ b/actions/deploy-cloudways/cloudways-entrypoint.sh
@@ -7,11 +7,15 @@
 #
 # Steps:
 # 1. Enable maintenance mode (bundled maintenance.php)
-# 2. Clean up legacy symlinks, sync plugins/themes/mu-plugins to public_html
-# 3. Keep only the newest release zips, remove old release folders
-# 4. Disable maintenance mode, flush redis/object caches when available
+# 2. Clean up legacy deployment symlinks, detect platform-managed ones
+# 3. Sync plugins/themes/mu-plugins to public_html
+# 4. Keep only the newest release zips, remove old release folders
+# 5. Disable maintenance mode, flush redis/object caches when available
 
 set -uo pipefail
+
+# Resolved before any cd: protected-paths.txt is uploaded next to this script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Directory layout (derived from pwd = <releases>/release/.deployment):
 export DEPLOYMENT_DIR=$(pwd)
@@ -19,10 +23,168 @@ export RELEASE_DIR="$(dirname "$DEPLOYMENT_DIR")"
 export RELEASES_DIR="$(dirname "$RELEASE_DIR")"
 export PRIVATE_DIR="$(dirname "$RELEASES_DIR")"
 export PUBLIC_DIR="$(dirname "$PRIVATE_DIR")/public_html"
+export CONTENT_DIR="$PUBLIC_DIR/wp-content"
 
 echo "Release:  $RELEASE_DIR"
 echo "Releases: $RELEASES_DIR"
 echo "Public:   $PUBLIC_DIR"
+
+# ---------------------------------------------------------------------------
+# Symlink + protected-path handling
+#
+# KEEP IN SYNC with the identical block in the sibling host entrypoints
+# (deploy-pressable, deploy-wpengine). Every action ships a self-contained
+# entrypoint by design — the ref you pin is the code that runs — so this block
+# is duplicated rather than sourced from a shared file.
+#
+# Managed hosts serve some plugins from platform-owned storage and link them
+# into the site: on Pressable, jetpack and woocommerce are usually symlinks in
+# wp-content/plugins rather than real folders. rsyncing a release copy onto such
+# a path is destructive either way — rsync follows the link and writes THROUGH
+# it (so --delete prunes files the platform owns), or the link is replaced by a
+# real directory and the site silently stops receiving platform updates.
+#
+# Rule: whatever is a symlink on the server is left exactly as it is. Projects
+# can protect additional paths that are still real folders through the deploy
+# action's protected-paths input (vars.PROTECTED_PATHS), which arrives as
+# protected-paths.txt next to this script.
+# ---------------------------------------------------------------------------
+
+PRESERVE_SYMLINKS="${PRESERVE_SYMLINKS:-true}"
+PROTECTED_PATHS_FILE="${PROTECTED_PATHS_FILE:-$SCRIPT_DIR/protected-paths.txt}"
+
+protected_patterns=() # wp-content-relative globs a deploy must never overwrite
+skip_reason=""        # set by should_skip() for the caller to log
+skipped_paths=()      # everything left untouched, for the closing summary
+
+load_protected_paths() {
+	local line
+	[ -f "$PROTECTED_PATHS_FILE" ] || return 0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line="$(printf '%s' "${line%%#*}" | sed -e 's#^[[:space:]/]*##' -e 's#[[:space:]/]*$##')"
+		[ -n "$line" ] && protected_patterns+=("$line")
+	done < "$PROTECTED_PATHS_FILE"
+	if [ ${#protected_patterns[@]} -gt 0 ]; then
+		echo "ℹ︎ Protected paths: ${protected_patterns[*]}"
+	fi
+}
+
+is_protected_path() {
+	local rel="$1" pattern
+	[ ${#protected_patterns[@]} -gt 0 ] || return 1
+	for pattern in "${protected_patterns[@]}"; do
+		# Unquoted right-hand side on purpose: entries are globs (woocommerce*).
+		# shellcheck disable=SC2053
+		[[ "$rel" == $pattern ]] && return 0
+		# A bare name (no slash) protects that folder wherever it lives, so
+		# "woocommerce" covers "plugins/woocommerce".
+		# shellcheck disable=SC2053
+		[[ "$pattern" != */* && "${rel##*/}" == $pattern ]] && return 0
+	done
+	return 1
+}
+
+# should_skip <wp-content-relative path> <destination on the server>
+should_skip() {
+	local rel="$1" dest="$2"
+	skip_reason=""
+	if [ "$PRESERVE_SYMLINKS" = "true" ] && [ -L "$dest" ]; then
+		skip_reason="platform symlink → $(readlink "$dest" 2>/dev/null || echo 'unknown target')"
+	elif is_protected_path "$rel"; then
+		skip_reason="protected by configuration"
+	else
+		return 1
+	fi
+	skipped_paths+=("$rel — $skip_reason")
+	return 0
+}
+
+# An undeclared symlink that the release also ships is the surprising case: the
+# project built that plugin expecting it to land, so say so loudly.
+report_skip() {
+	local rel="$1" shipped="$2"
+	if [ ! -e "$shipped" ]; then
+		echo "::notice::⤵︎ $rel left untouched — $skip_reason"
+	elif is_protected_path "$rel"; then
+		echo "::notice::⤵︎ $rel ships in this release but was not deployed — $skip_reason"
+	else
+		echo "::warning::⤵︎ $rel ships in this release but was NOT deployed — $skip_reason. Add it to PROTECTED_PATHS to make this explicit."
+	fi
+}
+
+# Print what the host manages, so the log explains itself and the paths worth
+# adding to PROTECTED_PATHS are easy to copy out.
+report_symlinks() {
+	local content_dir="$1" links link
+	[ -d "$content_dir" ] || return 0
+	links="$(find "$content_dir" -maxdepth 2 -type l 2>/dev/null | sort)"
+	if [ -z "$links" ]; then
+		echo "ℹ︎ No symlinks detected under $content_dir"
+		return 0
+	fi
+	echo "ℹ︎ Symlinks detected under $content_dir (this deploy will not overwrite them):"
+	while IFS= read -r link; do
+		[ -n "$link" ] || continue
+		echo "  • ${link#"$content_dir"/} → $(readlink "$link" 2>/dev/null || echo 'unknown target')"
+	done <<< "$links"
+}
+
+# sync_children <kind> <label> <source root> <destination root>
+# One rsync per child directory (plugins/, themes/), so a child that is
+# symlinked or protected can be skipped whole — neither the link nor whatever
+# it points at is touched.
+sync_children() {
+	local kind="$1" label="$2" src_root="$3" dest_root="$4"
+	local dir base rel dest
+	if [ -L "$dest_root" ]; then
+		echo "ℹ︎ $dest_root is itself a symlink → $(readlink "$dest_root") — syncing through it"
+	fi
+	for dir in "$src_root"/*/; do
+		[ -d "$dir" ] || continue
+		base="$(basename "$dir")"
+		rel="$kind/$base"
+		dest="$dest_root/$base"
+		if should_skip "$rel" "$dest"; then
+			report_skip "$rel" "$dir"
+			continue
+		fi
+		echo "Syncing $label: $base"
+		rsync "${RSYNC_OPTS[@]}" "$dir" "$dest"
+	done
+}
+
+# sync_tree <kind> <source root> <destination root>
+# One rsync for the whole directory, used where --delete is meant to prune
+# entries the project removed. Protection becomes an --exclude rule: rsync
+# neither overwrites nor deletes an excluded path.
+sync_tree() {
+	local kind="$1" src_root="$2" dest_root="$3"
+	local excludes=() entry base
+	if [ -L "$dest_root" ]; then
+		echo "ℹ︎ $dest_root is itself a symlink → $(readlink "$dest_root") — syncing through it"
+	fi
+	for entry in "$dest_root"/*; do
+		# -L as well as -e: a broken symlink still has to be preserved.
+		[ -e "$entry" ] || [ -L "$entry" ] || continue
+		base="$(basename "$entry")"
+		if should_skip "$kind/$base" "$entry"; then
+			report_skip "$kind/$base" "$src_root/$base"
+			excludes+=("--exclude=/$base")
+		fi
+	done
+	rsync "${RSYNC_OPTS[@]}" ${excludes[@]+"${excludes[@]}"} "$src_root/." "$dest_root"
+}
+
+report_skipped_summary() {
+	local path
+	[ ${#skipped_paths[@]} -gt 0 ] || return 0
+	echo "::notice::ℹ︎ ${#skipped_paths[@]} path(s) left untouched on the server:"
+	for path in "${skipped_paths[@]}"; do
+		echo "  • $path"
+	done
+}
+
+# --- end of shared block ---------------------------------------------------
 
 if [ ! -d "$PUBLIC_DIR" ]; then
   echo "::error::❌ Public directory not found at $PUBLIC_DIR"
@@ -35,22 +197,45 @@ cd "$PUBLIC_DIR"
 cp "$DEPLOYMENT_DIR/maintenance.php" "$PUBLIC_DIR/maintenance.php"
 wp maintenance-mode activate 2>/dev/null || true
 
-# Cleanup symlinks (from the legacy deployment process)
+# Cleanup symlinks left by the legacy deployment process, which pointed
+# wp-content/{themes,plugins,mu-plugins} at a release directory.
+#
+# v4 change: only links that point back into the deployment tree are removed.
+# v3 removed any symlink at these paths — on a host that legitimately serves one
+# of these directories from platform storage, that replaced the link with a real
+# folder and silently detached the site from platform updates.
 for legacy in themes plugins mu-plugins; do
-  if [ -L "$PUBLIC_DIR/wp-content/$legacy" ]; then
-    rm -rf "$PUBLIC_DIR/wp-content/$legacy"
-  fi
+  link="$CONTENT_DIR/$legacy"
+  [ -L "$link" ] || continue
+  target="$(readlink "$link" 2>/dev/null || echo '')"
+  case "$target" in
+    *private_html*|*/releases/*|*/release/*)
+      echo "ℹ︎ Removing legacy deployment symlink wp-content/$legacy → $target"
+      rm -rf "$link"
+      ;;
+    *)
+      echo "::notice::ℹ︎ wp-content/$legacy is a symlink → $target — leaving it in place"
+      ;;
+  esac
 done
 
-# Sync the release into the public folder
-rsync -arxcO --delete --no-perms --no-times "${RELEASE_DIR}/plugins/." "${PUBLIC_DIR}/wp-content/plugins"
-rsync -arxcO --delete --no-perms --no-times "${RELEASE_DIR}/themes/." "${PUBLIC_DIR}/wp-content/themes"
+load_protected_paths
+report_symlinks "$CONTENT_DIR"
+
+# Sync the release into the public folder. Cloudways syncs plugins/ and themes/
+# as whole trees so that --delete prunes what the project removed; protected and
+# symlinked children become --exclude rules, which rsync neither overwrites nor
+# deletes.
+RSYNC_OPTS=(-arxcO --delete --no-perms --no-times)
+sync_tree "plugins" "${RELEASE_DIR}/plugins" "${CONTENT_DIR}/plugins"
+sync_tree "themes" "${RELEASE_DIR}/themes" "${CONTENT_DIR}/themes"
 
 # Sync MU Plugins when present.
 # v4 change: no .distignore filtering here — the release was already cleaned
 # by the build-release action before it was zipped.
 if [ -d "${RELEASE_DIR}/mu-plugins/" ]; then
-  rsync -rxc --delete "${RELEASE_DIR}/mu-plugins/." "${PUBLIC_DIR}/wp-content/mu-plugins"
+  RSYNC_OPTS=(-rxc --delete)
+  sync_tree "mu-plugins" "${RELEASE_DIR}/mu-plugins" "${CONTENT_DIR}/mu-plugins"
 fi
 
 # Final cleanup: keep only the two newest release zips
@@ -89,5 +274,7 @@ fi
 if wp cli has-command cache 2>/dev/null; then
     wp cache flush
 fi
+
+report_skipped_summary
 
 echo "::notice::ℹ︎ Release sync complete"

--- a/actions/deploy-pressable/action.yml
+++ b/actions/deploy-pressable/action.yml
@@ -46,6 +46,14 @@ inputs:
     description: "Remote staging path for uploaded releases"
     required: false
     default: "/tmp/releases"
+  protected-paths:
+    description: "Paths this deploy must never overwrite, relative to wp-content — one per line, comma separated, or a JSON array. Globs are allowed (e.g. `plugins/woocommerce*`), and a bare name matches that folder in any of plugins/themes/mu-plugins. Anything that is a symlink on the server is skipped automatically; use this for paths that are still real folders but are managed outside the repo. Pressable's own jetpack and akismet are always protected."
+    required: false
+    default: ""
+  preserve-symlinks:
+    description: "Leave any plugin/theme/mu-plugin that is a symlink on the server exactly as it is instead of syncing over it (true/false). Pressable serves platform-managed plugins (jetpack, woocommerce) this way, and rsync would otherwise write through the link into platform-owned storage or replace the link with a real directory. Only set this to false if a deploy is meant to replace symlinks with real directories."
+    required: false
+    default: "true"
   maintenance-mode:
     description: "Enable Pressable maintenance mode during the sync (true/false)"
     required: false
@@ -121,6 +129,43 @@ runs:
           ControlPath $SSH_PATH/ctl/%C
         END
 
+    # Normalise the protection config here, on the runner, so the server-side
+    # entrypoint reads a plain one-path-per-line file — nothing project-supplied
+    # is ever interpolated into a remote shell command.
+    - name: Resolve symlink protection
+      id: protection
+      shell: bash
+      env:
+        PROTECTED_PATHS: ${{ inputs.protected-paths }}
+        PRESERVE_SYMLINKS: ${{ inputs.preserve-symlinks }}
+      run: |
+        list="$RUNNER_TEMP/protected-paths.txt"
+        : > "$list" # always written, so a stale file from a prior deploy is replaced
+        if [ -n "$PROTECTED_PATHS" ]; then
+          # Accept a JSON array (matching the THEMES/PLUGINS convention) or a
+          # comma/newline separated list.
+          if printf '%s' "$PROTECTED_PATHS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            printf '%s' "$PROTECTED_PATHS" | jq -r '.[]' >> "$list"
+          else
+            printf '%s\n' "$PROTECTED_PATHS" | tr ',' '\n' >> "$list"
+          fi
+          # Trim whitespace, wrapping quotes and leading/trailing slashes, then
+          # drop comments and blanks. Paths reach the server as bare
+          # wp-content-relative globs.
+          sed -i -e 's#^[[:space:]"/]*##' -e 's#[[:space:]"/]*$##' -e '/^#/d' -e '/^$/d' "$list"
+        fi
+        # Narrowed to a literal true/false before it reaches the ssh command line.
+        case "$PRESERVE_SYMLINKS" in
+          false|False|FALSE|0|no|No|NO) preserve=false ;;
+          *) preserve=true ;;
+        esac
+        echo "preserve=$preserve" >> "$GITHUB_OUTPUT"
+        echo "Preserve server symlinks: $preserve"
+        if [ -s "$list" ]; then
+          echo "Protected paths (never overwritten on the server):"
+          sed 's/^/  • /' "$list"
+        fi
+
     - name: Upload release and entrypoint
       id: upload
       shell: bash
@@ -144,6 +189,7 @@ runs:
         # v4: the entrypoint ships with this action instead of being wget'd
         # from a branch on the server.
         rsync -e "ssh -p 22" -W "${{ github.action_path }}/pressable-entrypoint.sh" "pressable:${{ inputs.deployment-path }}/entrypoint.sh"
+        rsync -e "ssh -p 22" -W "$RUNNER_TEMP/protected-paths.txt" "pressable:${{ inputs.deployment-path }}/protected-paths.txt"
 
     - name: Enable maintenance mode
       if: ${{ inputs.maintenance-mode == 'true' }}
@@ -154,8 +200,10 @@ runs:
 
     - name: Sync release on the server
       shell: bash
+      env:
+        PRESERVE_SYMLINKS: ${{ steps.protection.outputs.preserve }}
       run: |
-        ssh pressable "cd ${{ inputs.deployment-path }}/ && chmod +x ./entrypoint.sh && bash ./entrypoint.sh ${{ steps.upload.outputs.ts }}"
+        ssh pressable "cd ${{ inputs.deployment-path }}/ && chmod +x ./entrypoint.sh && PRESERVE_SYMLINKS=$PRESERVE_SYMLINKS bash ./entrypoint.sh ${{ steps.upload.outputs.ts }}"
 
     - name: Disable maintenance mode
       if: ${{ always() && inputs.maintenance-mode == 'true' }}

--- a/actions/deploy-pressable/pressable-entrypoint.sh
+++ b/actions/deploy-pressable/pressable-entrypoint.sh
@@ -7,17 +7,179 @@
 #
 # Steps:
 # 1. Unzip the uploaded release
-# 2. Sync plugins, themes and mu-plugins into the public directory
-# 3. Keep only the newest release zips, remove old release folders
-# 4. Flush the page cache when available
+# 2. Detect platform-managed symlinks and configured protected paths
+# 3. Sync plugins, themes and mu-plugins into the public directory
+# 4. Keep only the newest release zips, remove old release folders
+# 5. Flush the page cache when available
 
 set -uo pipefail
 
 release_folder_name=$1 # timestamp release zip name (without .zip)
 
+# Resolved before any cd: protected-paths.txt is uploaded next to this script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 export RELEASES_DIR=$(pwd)
 export PUBLIC_DIR="/srv/htdocs"
 export RELEASE_DIR="$RELEASES_DIR/release"
+export CONTENT_DIR="$PUBLIC_DIR/wp-content"
+
+# ---------------------------------------------------------------------------
+# Symlink + protected-path handling
+#
+# KEEP IN SYNC with the identical block in the sibling host entrypoints
+# (deploy-wpengine, deploy-cloudways). Every action ships a self-contained
+# entrypoint by design — the ref you pin is the code that runs — so this block
+# is duplicated rather than sourced from a shared file.
+#
+# Managed hosts serve some plugins from platform-owned storage and link them
+# into the site: on Pressable, jetpack and woocommerce are usually symlinks in
+# wp-content/plugins rather than real folders. rsyncing a release copy onto such
+# a path is destructive either way — rsync follows the link and writes THROUGH
+# it (so --delete prunes files the platform owns), or the link is replaced by a
+# real directory and the site silently stops receiving platform updates.
+#
+# Rule: whatever is a symlink on the server is left exactly as it is. Projects
+# can protect additional paths that are still real folders through the deploy
+# action's protected-paths input (vars.PROTECTED_PATHS), which arrives as
+# protected-paths.txt next to this script.
+# ---------------------------------------------------------------------------
+
+PRESERVE_SYMLINKS="${PRESERVE_SYMLINKS:-true}"
+PROTECTED_PATHS_FILE="${PROTECTED_PATHS_FILE:-$SCRIPT_DIR/protected-paths.txt}"
+
+protected_patterns=() # wp-content-relative globs a deploy must never overwrite
+skip_reason=""        # set by should_skip() for the caller to log
+skipped_paths=()      # everything left untouched, for the closing summary
+
+load_protected_paths() {
+	local line
+	[ -f "$PROTECTED_PATHS_FILE" ] || return 0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line="$(printf '%s' "${line%%#*}" | sed -e 's#^[[:space:]/]*##' -e 's#[[:space:]/]*$##')"
+		[ -n "$line" ] && protected_patterns+=("$line")
+	done < "$PROTECTED_PATHS_FILE"
+	if [ ${#protected_patterns[@]} -gt 0 ]; then
+		echo "ℹ︎ Protected paths: ${protected_patterns[*]}"
+	fi
+}
+
+is_protected_path() {
+	local rel="$1" pattern
+	[ ${#protected_patterns[@]} -gt 0 ] || return 1
+	for pattern in "${protected_patterns[@]}"; do
+		# Unquoted right-hand side on purpose: entries are globs (woocommerce*).
+		# shellcheck disable=SC2053
+		[[ "$rel" == $pattern ]] && return 0
+		# A bare name (no slash) protects that folder wherever it lives, so
+		# "woocommerce" covers "plugins/woocommerce".
+		# shellcheck disable=SC2053
+		[[ "$pattern" != */* && "${rel##*/}" == $pattern ]] && return 0
+	done
+	return 1
+}
+
+# should_skip <wp-content-relative path> <destination on the server>
+should_skip() {
+	local rel="$1" dest="$2"
+	skip_reason=""
+	if [ "$PRESERVE_SYMLINKS" = "true" ] && [ -L "$dest" ]; then
+		skip_reason="platform symlink → $(readlink "$dest" 2>/dev/null || echo 'unknown target')"
+	elif is_protected_path "$rel"; then
+		skip_reason="protected by configuration"
+	else
+		return 1
+	fi
+	skipped_paths+=("$rel — $skip_reason")
+	return 0
+}
+
+# An undeclared symlink that the release also ships is the surprising case: the
+# project built that plugin expecting it to land, so say so loudly.
+report_skip() {
+	local rel="$1" shipped="$2"
+	if [ ! -e "$shipped" ]; then
+		echo "::notice::⤵︎ $rel left untouched — $skip_reason"
+	elif is_protected_path "$rel"; then
+		echo "::notice::⤵︎ $rel ships in this release but was not deployed — $skip_reason"
+	else
+		echo "::warning::⤵︎ $rel ships in this release but was NOT deployed — $skip_reason. Add it to PROTECTED_PATHS to make this explicit."
+	fi
+}
+
+# Print what the host manages, so the log explains itself and the paths worth
+# adding to PROTECTED_PATHS are easy to copy out.
+report_symlinks() {
+	local content_dir="$1" links link
+	[ -d "$content_dir" ] || return 0
+	links="$(find "$content_dir" -maxdepth 2 -type l 2>/dev/null | sort)"
+	if [ -z "$links" ]; then
+		echo "ℹ︎ No symlinks detected under $content_dir"
+		return 0
+	fi
+	echo "ℹ︎ Symlinks detected under $content_dir (this deploy will not overwrite them):"
+	while IFS= read -r link; do
+		[ -n "$link" ] || continue
+		echo "  • ${link#"$content_dir"/} → $(readlink "$link" 2>/dev/null || echo 'unknown target')"
+	done <<< "$links"
+}
+
+# sync_children <kind> <label> <source root> <destination root>
+# One rsync per child directory (plugins/, themes/), so a child that is
+# symlinked or protected can be skipped whole — neither the link nor whatever
+# it points at is touched.
+sync_children() {
+	local kind="$1" label="$2" src_root="$3" dest_root="$4"
+	local dir base rel dest
+	if [ -L "$dest_root" ]; then
+		echo "ℹ︎ $dest_root is itself a symlink → $(readlink "$dest_root") — syncing through it"
+	fi
+	for dir in "$src_root"/*/; do
+		[ -d "$dir" ] || continue
+		base="$(basename "$dir")"
+		rel="$kind/$base"
+		dest="$dest_root/$base"
+		if should_skip "$rel" "$dest"; then
+			report_skip "$rel" "$dir"
+			continue
+		fi
+		echo "Syncing $label: $base"
+		rsync "${RSYNC_OPTS[@]}" "$dir" "$dest"
+	done
+}
+
+# sync_tree <kind> <source root> <destination root>
+# One rsync for the whole directory, used where --delete is meant to prune
+# entries the project removed. Protection becomes an --exclude rule: rsync
+# neither overwrites nor deletes an excluded path.
+sync_tree() {
+	local kind="$1" src_root="$2" dest_root="$3"
+	local excludes=() entry base
+	if [ -L "$dest_root" ]; then
+		echo "ℹ︎ $dest_root is itself a symlink → $(readlink "$dest_root") — syncing through it"
+	fi
+	for entry in "$dest_root"/*; do
+		# -L as well as -e: a broken symlink still has to be preserved.
+		[ -e "$entry" ] || [ -L "$entry" ] || continue
+		base="$(basename "$entry")"
+		if should_skip "$kind/$base" "$entry"; then
+			report_skip "$kind/$base" "$src_root/$base"
+			excludes+=("--exclude=/$base")
+		fi
+	done
+	rsync "${RSYNC_OPTS[@]}" ${excludes[@]+"${excludes[@]}"} "$src_root/." "$dest_root"
+}
+
+report_skipped_summary() {
+	local path
+	[ ${#skipped_paths[@]} -gt 0 ] || return 0
+	echo "::notice::ℹ︎ ${#skipped_paths[@]} path(s) left untouched on the server:"
+	for path in "${skipped_paths[@]}"; do
+		echo "  • $path"
+	done
+}
+
+# --- end of shared block ---------------------------------------------------
 
 # Every release starts from a clean extraction directory
 if [ -d "$RELEASE_DIR" ]; then
@@ -34,42 +196,37 @@ chmod a+r "$RELEASES_DIR/$release_folder_name.zip"
 chmod g+wx "$RELEASES_DIR"
 unzip -o -q -d "$RELEASE_DIR" "$RELEASES_DIR/$release_folder_name.zip"
 
+# Pressable manages jetpack and akismet itself however they appear on disk (v3
+# deleted them from the release; now they are protected paths, so the deploy log
+# says why they did not land). Seeded before the project's own list is loaded.
+protected_patterns+=("plugins/jetpack" "plugins/akismet")
+load_protected_paths
+report_symlinks "$CONTENT_DIR"
+
+RSYNC_OPTS=(-arxW --inplace --delete)
+
 # Sync Plugins
 if [[ -d "${RELEASE_DIR}/plugins/" ]]; then
-	cd "$RELEASE_DIR/plugins"
-
-	# On Pressable, jetpack and akismet are managed by the platform
-	rm -rf "${RELEASE_DIR}/plugins/jetpack" "${RELEASE_DIR}/plugins/akismet"
-
-	for dir in ./*/
-	do
-		base=$(basename "$dir")
-		echo "Syncing Plugin: $base"
-		rsync -arxW --inplace --delete "$dir" "${PUBLIC_DIR}/wp-content/plugins/$base"
-	done
+	sync_children "plugins" "Plugin" "$RELEASE_DIR/plugins" "$CONTENT_DIR/plugins"
 else
 	echo "::error::❌ Plugins directory not found at ${RELEASE_DIR}/plugins/"
 fi
 
 # Sync Themes
 if [[ -d "${RELEASE_DIR}/themes/" ]]; then
-	cd "$RELEASE_DIR/themes"
-
-	for dir in ./*/
-	do
-		base=$(basename "$dir")
-		echo "Syncing Theme: $base"
-		rsync -arxW --inplace --delete "$dir" "${PUBLIC_DIR}/wp-content/themes/$base"
-	done
+	sync_children "themes" "Theme" "$RELEASE_DIR/themes" "$CONTENT_DIR/themes"
 else
 	echo "::error::❌ Themes directory not found at ${RELEASE_DIR}/themes/"
 fi
 
 # Sync MU Plugins when present.
 # v4 change: no .distignore filtering here — the release was already cleaned
-# by the build-release action before it was zipped.
+# by the build-release action before it was zipped. mu-plugins is synced as one
+# tree (its files sit at the root rather than one folder per plugin), so
+# platform-managed entries are protected with --exclude instead of being skipped
+# — without that, --delete would remove the host's own mu-plugins.
 if [[ -d "${RELEASE_DIR}/mu-plugins/" ]]; then
-	rsync -arxW --inplace --delete "${RELEASE_DIR}/mu-plugins/." "${PUBLIC_DIR}/wp-content/mu-plugins"
+	sync_tree "mu-plugins" "$RELEASE_DIR/mu-plugins" "$CONTENT_DIR/mu-plugins"
 fi
 
 # Final cleanup within the releases directory: keep only the two newest zips
@@ -93,5 +250,7 @@ cd "$PUBLIC_DIR"
 if wp cli has-command page-cache 2>/dev/null; then
     wp page-cache flush
 fi
+
+report_skipped_summary
 
 echo "::notice::ℹ︎ Release sync complete"

--- a/actions/deploy-wpengine/action.yml
+++ b/actions/deploy-wpengine/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: "Remote staging path for uploaded releases, relative to the site root"
     required: false
     default: "_wpeprivate/releases"
+  protected-paths:
+    description: "Paths this deploy must never overwrite, relative to wp-content — one per line, comma separated, or a JSON array. Globs are allowed (e.g. `plugins/woocommerce*`), and a bare name matches that folder in any of plugins/themes/mu-plugins. Anything that is a symlink on the server is skipped automatically; use this for paths that are still real folders but are managed outside the repo."
+    required: false
+    default: ""
+  preserve-symlinks:
+    description: "Leave any plugin/theme/mu-plugin that is a symlink on the server exactly as it is instead of syncing over it (true/false). Without this, rsync writes through the link into whatever storage the platform manages, or replaces the link with a real directory. Only set this to false if a deploy is meant to replace symlinks with real directories."
+    required: false
+    default: "true"
   post-deploy-command:
     description: "Optional shell command(s) run on the server (from the site root) after the sync"
     required: false
@@ -70,6 +78,43 @@ runs:
           ControlPath $SSH_PATH/ctl/%C
         END
 
+    # Normalise the protection config here, on the runner, so the server-side
+    # entrypoint reads a plain one-path-per-line file — nothing project-supplied
+    # is ever interpolated into a remote shell command.
+    - name: Resolve symlink protection
+      id: protection
+      shell: bash
+      env:
+        PROTECTED_PATHS: ${{ inputs.protected-paths }}
+        PRESERVE_SYMLINKS: ${{ inputs.preserve-symlinks }}
+      run: |
+        list="$RUNNER_TEMP/protected-paths.txt"
+        : > "$list" # always written, so a stale file from a prior deploy is replaced
+        if [ -n "$PROTECTED_PATHS" ]; then
+          # Accept a JSON array (matching the THEMES/PLUGINS convention) or a
+          # comma/newline separated list.
+          if printf '%s' "$PROTECTED_PATHS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            printf '%s' "$PROTECTED_PATHS" | jq -r '.[]' >> "$list"
+          else
+            printf '%s\n' "$PROTECTED_PATHS" | tr ',' '\n' >> "$list"
+          fi
+          # Trim whitespace, wrapping quotes and leading/trailing slashes, then
+          # drop comments and blanks. Paths reach the server as bare
+          # wp-content-relative globs.
+          sed -i -e 's#^[[:space:]"/]*##' -e 's#[[:space:]"/]*$##' -e '/^#/d' -e '/^$/d' "$list"
+        fi
+        # Narrowed to a literal true/false before it reaches the ssh command line.
+        case "$PRESERVE_SYMLINKS" in
+          false|False|FALSE|0|no|No|NO) preserve=false ;;
+          *) preserve=true ;;
+        esac
+        echo "preserve=$preserve" >> "$GITHUB_OUTPUT"
+        echo "Preserve server symlinks: $preserve"
+        if [ -s "$list" ]; then
+          echo "Protected paths (never overwritten on the server):"
+          sed 's/^/  • /' "$list"
+        fi
+
     - name: Upload release and entrypoint
       id: upload
       shell: bash
@@ -92,13 +137,15 @@ runs:
         # Land it on the server as $ts.zip regardless of the local filename.
         rsync -e "ssh -p 22" -W "$zip_path" "wpengine:$REMOTE_BASE/$ts.zip"
         rsync -e "ssh -p 22" -W "${{ github.action_path }}/wpengine-entrypoint.sh" "wpengine:$REMOTE_BASE/entrypoint.sh"
+        rsync -e "ssh -p 22" -W "$RUNNER_TEMP/protected-paths.txt" "wpengine:$REMOTE_BASE/protected-paths.txt"
 
     - name: Sync release on the server
       shell: bash
       env:
         REMOTE_BASE: "~/sites/${{ inputs.install-name }}/${{ inputs.deployment-path }}"
+        PRESERVE_SYMLINKS: ${{ steps.protection.outputs.preserve }}
       run: |
-        ssh wpengine "cd $REMOTE_BASE/ && chmod +x ./entrypoint.sh && bash ./entrypoint.sh ${{ steps.upload.outputs.ts }}"
+        ssh wpengine "cd $REMOTE_BASE/ && chmod +x ./entrypoint.sh && PRESERVE_SYMLINKS=$PRESERVE_SYMLINKS bash ./entrypoint.sh ${{ steps.upload.outputs.ts }}"
 
     - name: Run post-deploy command
       if: ${{ inputs.post-deploy-command != '' }}

--- a/actions/deploy-wpengine/wpengine-entrypoint.sh
+++ b/actions/deploy-wpengine/wpengine-entrypoint.sh
@@ -8,23 +8,185 @@
 #
 # Steps:
 # 1. Unzip the uploaded release
-# 2. Sync plugins, themes and mu-plugins into the public directory
-# 3. Keep only the newest release zips, remove old release folders
-# 4. Clear maintenance mode if active, flush caches when available
+# 2. Detect platform-managed symlinks and configured protected paths
+# 3. Sync plugins, themes and mu-plugins into the public directory
+# 4. Keep only the newest release zips, remove old release folders
+# 5. Clear maintenance mode if active, flush caches when available
 
 set -uo pipefail
 
 release_folder_name=$1 # timestamp release zip name (without .zip)
+
+# Resolved before any cd: protected-paths.txt is uploaded next to this script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Run from <site>/_wpeprivate/releases
 export RELEASES_DIR=$(pwd)
 export PRIVATE_DIR="$(dirname "$RELEASES_DIR")"
 export PUBLIC_DIR="$(dirname "$PRIVATE_DIR")"
 export RELEASE_DIR="$RELEASES_DIR/release"
+export CONTENT_DIR="$PUBLIC_DIR/wp-content"
 
 echo "Releases: $RELEASES_DIR"
 echo "Release:  $RELEASE_DIR"
 echo "Public:   $PUBLIC_DIR"
+
+# ---------------------------------------------------------------------------
+# Symlink + protected-path handling
+#
+# KEEP IN SYNC with the identical block in the sibling host entrypoints
+# (deploy-pressable, deploy-cloudways). Every action ships a self-contained
+# entrypoint by design — the ref you pin is the code that runs — so this block
+# is duplicated rather than sourced from a shared file.
+#
+# Managed hosts serve some plugins from platform-owned storage and link them
+# into the site: on Pressable, jetpack and woocommerce are usually symlinks in
+# wp-content/plugins rather than real folders. rsyncing a release copy onto such
+# a path is destructive either way — rsync follows the link and writes THROUGH
+# it (so --delete prunes files the platform owns), or the link is replaced by a
+# real directory and the site silently stops receiving platform updates.
+#
+# Rule: whatever is a symlink on the server is left exactly as it is. Projects
+# can protect additional paths that are still real folders through the deploy
+# action's protected-paths input (vars.PROTECTED_PATHS), which arrives as
+# protected-paths.txt next to this script.
+# ---------------------------------------------------------------------------
+
+PRESERVE_SYMLINKS="${PRESERVE_SYMLINKS:-true}"
+PROTECTED_PATHS_FILE="${PROTECTED_PATHS_FILE:-$SCRIPT_DIR/protected-paths.txt}"
+
+protected_patterns=() # wp-content-relative globs a deploy must never overwrite
+skip_reason=""        # set by should_skip() for the caller to log
+skipped_paths=()      # everything left untouched, for the closing summary
+
+load_protected_paths() {
+	local line
+	[ -f "$PROTECTED_PATHS_FILE" ] || return 0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line="$(printf '%s' "${line%%#*}" | sed -e 's#^[[:space:]/]*##' -e 's#[[:space:]/]*$##')"
+		[ -n "$line" ] && protected_patterns+=("$line")
+	done < "$PROTECTED_PATHS_FILE"
+	if [ ${#protected_patterns[@]} -gt 0 ]; then
+		echo "ℹ︎ Protected paths: ${protected_patterns[*]}"
+	fi
+}
+
+is_protected_path() {
+	local rel="$1" pattern
+	[ ${#protected_patterns[@]} -gt 0 ] || return 1
+	for pattern in "${protected_patterns[@]}"; do
+		# Unquoted right-hand side on purpose: entries are globs (woocommerce*).
+		# shellcheck disable=SC2053
+		[[ "$rel" == $pattern ]] && return 0
+		# A bare name (no slash) protects that folder wherever it lives, so
+		# "woocommerce" covers "plugins/woocommerce".
+		# shellcheck disable=SC2053
+		[[ "$pattern" != */* && "${rel##*/}" == $pattern ]] && return 0
+	done
+	return 1
+}
+
+# should_skip <wp-content-relative path> <destination on the server>
+should_skip() {
+	local rel="$1" dest="$2"
+	skip_reason=""
+	if [ "$PRESERVE_SYMLINKS" = "true" ] && [ -L "$dest" ]; then
+		skip_reason="platform symlink → $(readlink "$dest" 2>/dev/null || echo 'unknown target')"
+	elif is_protected_path "$rel"; then
+		skip_reason="protected by configuration"
+	else
+		return 1
+	fi
+	skipped_paths+=("$rel — $skip_reason")
+	return 0
+}
+
+# An undeclared symlink that the release also ships is the surprising case: the
+# project built that plugin expecting it to land, so say so loudly.
+report_skip() {
+	local rel="$1" shipped="$2"
+	if [ ! -e "$shipped" ]; then
+		echo "::notice::⤵︎ $rel left untouched — $skip_reason"
+	elif is_protected_path "$rel"; then
+		echo "::notice::⤵︎ $rel ships in this release but was not deployed — $skip_reason"
+	else
+		echo "::warning::⤵︎ $rel ships in this release but was NOT deployed — $skip_reason. Add it to PROTECTED_PATHS to make this explicit."
+	fi
+}
+
+# Print what the host manages, so the log explains itself and the paths worth
+# adding to PROTECTED_PATHS are easy to copy out.
+report_symlinks() {
+	local content_dir="$1" links link
+	[ -d "$content_dir" ] || return 0
+	links="$(find "$content_dir" -maxdepth 2 -type l 2>/dev/null | sort)"
+	if [ -z "$links" ]; then
+		echo "ℹ︎ No symlinks detected under $content_dir"
+		return 0
+	fi
+	echo "ℹ︎ Symlinks detected under $content_dir (this deploy will not overwrite them):"
+	while IFS= read -r link; do
+		[ -n "$link" ] || continue
+		echo "  • ${link#"$content_dir"/} → $(readlink "$link" 2>/dev/null || echo 'unknown target')"
+	done <<< "$links"
+}
+
+# sync_children <kind> <label> <source root> <destination root>
+# One rsync per child directory (plugins/, themes/), so a child that is
+# symlinked or protected can be skipped whole — neither the link nor whatever
+# it points at is touched.
+sync_children() {
+	local kind="$1" label="$2" src_root="$3" dest_root="$4"
+	local dir base rel dest
+	if [ -L "$dest_root" ]; then
+		echo "ℹ︎ $dest_root is itself a symlink → $(readlink "$dest_root") — syncing through it"
+	fi
+	for dir in "$src_root"/*/; do
+		[ -d "$dir" ] || continue
+		base="$(basename "$dir")"
+		rel="$kind/$base"
+		dest="$dest_root/$base"
+		if should_skip "$rel" "$dest"; then
+			report_skip "$rel" "$dir"
+			continue
+		fi
+		echo "Syncing $label: $base"
+		rsync "${RSYNC_OPTS[@]}" "$dir" "$dest"
+	done
+}
+
+# sync_tree <kind> <source root> <destination root>
+# One rsync for the whole directory, used where --delete is meant to prune
+# entries the project removed. Protection becomes an --exclude rule: rsync
+# neither overwrites nor deletes an excluded path.
+sync_tree() {
+	local kind="$1" src_root="$2" dest_root="$3"
+	local excludes=() entry base
+	if [ -L "$dest_root" ]; then
+		echo "ℹ︎ $dest_root is itself a symlink → $(readlink "$dest_root") — syncing through it"
+	fi
+	for entry in "$dest_root"/*; do
+		# -L as well as -e: a broken symlink still has to be preserved.
+		[ -e "$entry" ] || [ -L "$entry" ] || continue
+		base="$(basename "$entry")"
+		if should_skip "$kind/$base" "$entry"; then
+			report_skip "$kind/$base" "$src_root/$base"
+			excludes+=("--exclude=/$base")
+		fi
+	done
+	rsync "${RSYNC_OPTS[@]}" ${excludes[@]+"${excludes[@]}"} "$src_root/." "$dest_root"
+}
+
+report_skipped_summary() {
+	local path
+	[ ${#skipped_paths[@]} -gt 0 ] || return 0
+	echo "::notice::ℹ︎ ${#skipped_paths[@]} path(s) left untouched on the server:"
+	for path in "${skipped_paths[@]}"; do
+		echo "  • $path"
+	done
+}
+
+# --- end of shared block ---------------------------------------------------
 
 # Every release starts from a clean extraction directory
 if [ -d "$RELEASE_DIR" ]; then
@@ -41,33 +203,29 @@ chmod a+r "$RELEASES_DIR/$release_folder_name.zip"
 chmod g+wx "$RELEASES_DIR"
 unzip -o -q -d "$RELEASE_DIR" "$RELEASES_DIR/$release_folder_name.zip"
 
+load_protected_paths
+report_symlinks "$CONTENT_DIR"
+
+RSYNC_OPTS=(-arxW --inplace --delete)
+
 # Sync Plugins
 if [[ -d "${RELEASE_DIR}/plugins/" ]]; then
-	cd "$RELEASE_DIR/plugins"
-	for dir in ./*/
-	do
-		base=$(basename "$dir")
-		echo "Syncing Plugin: $base"
-		rsync -arxW --inplace --delete "$dir" "${PUBLIC_DIR}/wp-content/plugins/$base"
-	done
+	sync_children "plugins" "Plugin" "$RELEASE_DIR/plugins" "$CONTENT_DIR/plugins"
 fi
 
 # Sync Themes
 if [[ -d "${RELEASE_DIR}/themes/" ]]; then
-	cd "$RELEASE_DIR/themes"
-	for dir in ./*/
-	do
-		base=$(basename "$dir")
-		echo "Syncing Theme: $base"
-		rsync -arxW --inplace --delete "$dir" "${PUBLIC_DIR}/wp-content/themes/$base"
-	done
+	sync_children "themes" "Theme" "$RELEASE_DIR/themes" "$CONTENT_DIR/themes"
 fi
 
 # Sync MU Plugins when present.
 # v4 change: no .distignore filtering here — the release was already cleaned
-# by the build-release action before it was zipped.
+# by the build-release action before it was zipped. mu-plugins is synced as one
+# tree (its files sit at the root rather than one folder per plugin), so
+# platform-managed entries are protected with --exclude instead of being skipped
+# — without that, --delete would remove the host's own mu-plugins.
 if [[ -d "${RELEASE_DIR}/mu-plugins/" ]]; then
-	rsync -arxW --inplace --delete "${RELEASE_DIR}/mu-plugins/." "${PUBLIC_DIR}/wp-content/mu-plugins"
+	sync_tree "mu-plugins" "$RELEASE_DIR/mu-plugins" "$CONTENT_DIR/mu-plugins"
 fi
 
 # Final cleanup within the releases directory: keep only the two newest zips
@@ -108,5 +266,7 @@ fi
 if wp cli has-command page-cache 2>/dev/null; then
     wp page-cache flush
 fi
+
+report_skipped_summary
 
 echo "::notice::ℹ︎ Release sync complete"

--- a/actions/remote-plugin-install/action.yml
+++ b/actions/remote-plugin-install/action.yml
@@ -1,0 +1,157 @@
+name: "Remote Plugin Install"
+description: >-
+  Reconcile the third-party plugins and themes in composer.lock with what is
+  installed on the server, using one short-run WP-CLI call per package over SSH.
+  Pair it with a host deploy action: the release ships only your own code, and
+  everything Composer manages is resolved on the server from the lock file.
+
+  v4 note (previous/next): in v3 this was .deployment/remote-plugin-install.sh,
+  gated behind vars.REMOTE_PLUGIN_INSTALL and never ported past WP Engine. That
+  script hardcoded /home/wpe-user paths and the `wpengine` SSH alias, ran its
+  fallback `wp plugin install` on the RUNNER instead of over SSH (so the fallback
+  could never work), opened a fresh SSH connection per package, counted with
+  `((var++))` (which returns 1 on the first increment and would abort under
+  `set -e`), and compared versions with `php -r version_compare` so it only ever
+  upgraded — rolling back to an older release left third-party plugins ahead of
+  the lock. v4 fixes all of that, takes the host layout as inputs, reuses one
+  multiplexed SSH connection, treats the lock as the source of truth in both
+  directions, skips platform symlinks and protected paths, and verifies the
+  result before reporting success.
+
+  Deliberately NOT `composer install` on the server (the "SSH build" in
+  Pressable's Composer Workflows doc): managed containers cap a single exec at
+  ~300s, which a cold Composer install for a large project does not reliably fit
+  inside, and it would fail mid-write with maintenance mode already on. One short
+  WP-CLI call per package stays well inside the cap and keeps Composer and
+  registry credentials off the server entirely.
+
+inputs:
+  ssh-host:
+    description: "SSH host"
+    required: true
+  ssh-user:
+    description: "SSH user"
+    required: true
+  ssh-key:
+    description: "SSH private key. Password auth is not supported by this action — Cloudways Autonomous (DEPLOYMENT_AUTH_TYPE=pass) installs cannot use remote plugin install yet."
+    required: true
+  wp-path:
+    description: "Absolute (or ~-relative) path to the WordPress root on the server. Pressable: /srv/htdocs. WP Engine: ~/sites/<install>. Cloudways: ~/public_html."
+    required: true
+  composer-lock:
+    description: "Path to composer.lock on the runner. It is the source of truth: any package whose installed version differs is reinstalled at the locked version, so a rollback downgrades rather than leaving plugins ahead."
+    required: false
+    default: "composer.lock"
+  protected-paths:
+    description: "Paths this action must never install over, relative to wp-content — same format as the deploy actions (one per line, comma separated, or a JSON array; globs allowed)."
+    required: false
+    default: ""
+  preserve-symlinks:
+    description: "Skip any package whose target directory is a symlink on the server (true/false). Composer's installer-paths would delete such a link and replace it with a real directory; WP-CLI would too, so this is checked before every install."
+    required: false
+    default: "true"
+  package-auth-host:
+    description: "Hostname of the private Composer registry whose dist URLs need credentials (e.g. packagist.linchpin.com). Packages served from anywhere else are downloaded unauthenticated."
+    required: false
+    default: "packagist.linchpin.com"
+  package-auth-user:
+    description: "Username for the private registry (v3's SATISPRESS_USER)"
+    required: false
+    default: ""
+  package-auth-password:
+    description: "Password for the private registry (v3's SATISPRESS_PASSWORD)"
+    required: false
+    default: ""
+  dry-run:
+    description: "Print the plan and make no changes (true/false)"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure SSH connection
+      shell: bash
+      env:
+        SSH_HOST: ${{ inputs.ssh-host }}
+        SSH_USER: ${{ inputs.ssh-user }}
+        SSH_KEY: ${{ inputs.ssh-key }}
+      run: |
+        SSH_PATH="$HOME/.ssh"
+        mkdir -p "$SSH_PATH" "$SSH_PATH/ctl"
+        ssh-keyscan -t rsa "$SSH_HOST" >> "$SSH_PATH/known_hosts" 2>/dev/null
+        echo "$SSH_KEY" > "$SSH_PATH/remote_install"
+        chmod 700 "$SSH_PATH"
+        chmod 644 "$SSH_PATH/known_hosts"
+        chmod 600 "$SSH_PATH/remote_install"
+        # Its own alias, so pairing this action with a host deploy action in the
+        # same job does not collide with that action's Host block. ControlPath %C
+        # hashes host/port/user rather than the alias, so the two aliases still
+        # share one multiplexed connection — the per-package calls below cost a
+        # single handshake between them.
+        cat >> "$SSH_PATH/config" <<END
+          Host remoteinstall
+          HostName $SSH_HOST
+          User $SSH_USER
+          IdentityFile $SSH_PATH/remote_install
+          StrictHostKeyChecking no
+          ControlMaster auto
+          ControlPath $SSH_PATH/ctl/%C
+          ControlPersist 60
+        END
+
+    # Same normalisation as the deploy actions, so PROTECTED_PATHS means exactly
+    # the same thing whether a package arrives over rsync or over WP-CLI.
+    - name: Resolve symlink protection
+      id: protection
+      shell: bash
+      env:
+        PROTECTED_PATHS: ${{ inputs.protected-paths }}
+        PRESERVE_SYMLINKS: ${{ inputs.preserve-symlinks }}
+      run: |
+        list="$RUNNER_TEMP/protected-paths.txt"
+        : > "$list" # always written, so a stale file from a prior deploy is replaced
+        if [ -n "$PROTECTED_PATHS" ]; then
+          # Accept a JSON array (matching the THEMES/PLUGINS convention) or a
+          # comma/newline separated list.
+          if printf '%s' "$PROTECTED_PATHS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            printf '%s' "$PROTECTED_PATHS" | jq -r '.[]' >> "$list"
+          else
+            printf '%s\n' "$PROTECTED_PATHS" | tr ',' '\n' >> "$list"
+          fi
+          # Trim whitespace, wrapping quotes and leading/trailing slashes, then
+          # drop comments and blanks. Paths reach the server as bare
+          # wp-content-relative globs.
+          sed -i -e 's#^[[:space:]"/]*##' -e 's#[[:space:]"/]*$##' -e '/^#/d' -e '/^$/d' "$list"
+        fi
+        # Narrowed to a literal true/false before it reaches the ssh command line.
+        case "$PRESERVE_SYMLINKS" in
+          false|False|FALSE|0|no|No|NO) preserve=false ;;
+          *) preserve=true ;;
+        esac
+        echo "preserve=$preserve" >> "$GITHUB_OUTPUT"
+        echo "Preserve server symlinks: $preserve"
+        if [ -s "$list" ]; then
+          echo "Protected paths (never installed over):"
+          sed 's/^/  • /' "$list"
+        fi
+
+    - name: Reconcile packages from composer.lock
+      shell: bash
+      env:
+        SSH_ALIAS: remoteinstall
+        WP_PATH: ${{ inputs.wp-path }}
+        COMPOSER_LOCK: ${{ inputs.composer-lock }}
+        PROTECTED_PATHS_FILE: ${{ runner.temp }}/protected-paths.txt
+        PRESERVE_SYMLINKS: ${{ steps.protection.outputs.preserve }}
+        PACKAGE_AUTH_HOST: ${{ inputs.package-auth-host }}
+        PACKAGE_AUTH_USER: ${{ inputs.package-auth-user }}
+        PACKAGE_AUTH_PASSWORD: ${{ inputs.package-auth-password }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        # WP-CLI echoes the URL it downloads from, and that URL carries registry
+        # credentials for private packages. Mask both halves so neither shows up
+        # in the run log.
+        if [ -n "$PACKAGE_AUTH_USER" ]; then echo "::add-mask::$PACKAGE_AUTH_USER"; fi
+        if [ -n "$PACKAGE_AUTH_PASSWORD" ]; then echo "::add-mask::$PACKAGE_AUTH_PASSWORD"; fi
+        bash "${{ github.action_path }}/remote-plugin-install.sh"

--- a/actions/remote-plugin-install/remote-plugin-install.sh
+++ b/actions/remote-plugin-install/remote-plugin-install.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+
+# Reconcile the third-party plugins and themes in composer.lock with what is
+# actually installed on the server, using short-run WP-CLI calls over SSH.
+#
+# Runs ON THE GITHUB RUNNER — not on the server. This is the v4 port of
+# .deployment/remote-plugin-install.sh.
+#
+# Why not `composer install` on the server (the "SSH build" in Pressable's
+# Composer Workflows doc)? Managed containers cap a single exec at ~300s, and a
+# cold Composer install for a WooCommerce-scale project does not reliably fit
+# inside that — it would die mid-write, with maintenance mode already on and
+# wp-content half updated. Driving one short WP-CLI call per package keeps every
+# exec well inside the cap, keeps Composer and private-registry credentials off
+# the server entirely, and leaves dependency resolution on the runner where it is
+# already cached. SSH connection reuse (ControlMaster) means the many calls still
+# cost one handshake.
+#
+# The lock file is the source of truth: a package whose installed version does
+# not match the lock is reinstalled AT THE LOCKED VERSION, so rolling back to an
+# older release downgrades plugins instead of leaving them ahead. v3 compared
+# with version_compare and only ever upgraded, which silently made rollbacks a
+# no-op for third-party plugins.
+#
+# Expects (all via the environment, set by action.yml):
+#   SSH_ALIAS, WP_PATH, COMPOSER_LOCK, PROTECTED_PATHS_FILE, PRESERVE_SYMLINKS,
+#   PACKAGE_AUTH_HOST, PACKAGE_AUTH_USER, PACKAGE_AUTH_PASSWORD, DRY_RUN
+
+set -uo pipefail
+
+SSH_ALIAS="${SSH_ALIAS:-remoteinstall}"
+WP_PATH="${WP_PATH:?WP_PATH is required}"
+COMPOSER_LOCK="${COMPOSER_LOCK:?COMPOSER_LOCK is required}"
+PROTECTED_PATHS_FILE="${PROTECTED_PATHS_FILE:-}"
+PRESERVE_SYMLINKS="${PRESERVE_SYMLINKS:-true}"
+PACKAGE_AUTH_HOST="${PACKAGE_AUTH_HOST:-}"
+PACKAGE_AUTH_USER="${PACKAGE_AUTH_USER:-}"
+PACKAGE_AUTH_PASSWORD="${PACKAGE_AUTH_PASSWORD:-}"
+DRY_RUN="${DRY_RUN:-false}"
+
+if [ ! -f "$COMPOSER_LOCK" ]; then
+	echo "::error::composer.lock not found at $COMPOSER_LOCK. Remote plugin install needs the lock file in the release — check that the project .distignore does not exclude it."
+	exit 1
+fi
+
+# WP_PATH is interpolated into a remote command, so constrain it rather than
+# trusting whatever a repo variable holds.
+if [[ ! "$WP_PATH" =~ ^[A-Za-z0-9._~/-]+$ ]]; then
+	echo "::error::wp-path contains characters that are not allowed in a remote path: $WP_PATH"
+	exit 1
+fi
+
+# --- protected paths (same contract as the deploy entrypoints) --------------
+
+protected_patterns=()
+if [ -n "$PROTECTED_PATHS_FILE" ] && [ -f "$PROTECTED_PATHS_FILE" ]; then
+	while IFS= read -r line || [ -n "$line" ]; do
+		[ -n "$line" ] && protected_patterns+=("$line")
+	done < "$PROTECTED_PATHS_FILE"
+fi
+
+is_protected_path() {
+	local rel="$1" pattern
+	[ ${#protected_patterns[@]} -gt 0 ] || return 1
+	for pattern in "${protected_patterns[@]}"; do
+		# Unquoted right-hand side on purpose: entries are globs (woocommerce*).
+		# shellcheck disable=SC2053
+		[[ "$rel" == $pattern ]] && return 0
+		# shellcheck disable=SC2053
+		[[ "$pattern" != */* && "${rel##*/}" == $pattern ]] && return 0
+	done
+	return 1
+}
+
+# --- version comparison ----------------------------------------------------
+
+# Composer and WordPress spell the same release differently often enough that a
+# naive string compare would reinstall half the site on every deploy: the lock
+# may say "v8.0.0" where the plugin header says "8.0". Strip a leading v, drop
+# build metadata, and collapse trailing zero segments so 8.0.0 == 8.0 == 8.
+# Replaces v3's `php -r "version_compare(...)"` shell-out.
+normalize_version() {
+	local v="${1#v}"
+	v="${v%%+*}"
+	while [[ "$v" == *.0 ]]; do v="${v%.0}"; done
+	printf '%s' "$v"
+}
+
+# --- remote state ----------------------------------------------------------
+
+echo "➤ Reading installed plugins, themes and symlinks from the server"
+
+# One exec for the whole snapshot. --skip-plugins/--skip-themes so a fatal in
+# somebody else's plugin cannot blind the inventory.
+remote_state=$(ssh -n "$SSH_ALIAS" "cd '$WP_PATH' || exit 9; \
+wp plugin list --format=json --fields=name,version,status --skip-plugins --skip-themes 2>/dev/null || echo '[]'; \
+echo '@@SPLIT@@'; \
+wp theme list --format=json --fields=name,version,status --skip-plugins --skip-themes 2>/dev/null || echo '[]'; \
+echo '@@SPLIT@@'; \
+find wp-content/plugins wp-content/themes -maxdepth 1 -type l 2>/dev/null || true")
+ssh_status=$?
+
+if [ "$ssh_status" -eq 9 ]; then
+	echo "::error::Could not enter $WP_PATH on the server"
+	exit 1
+elif [ "$ssh_status" -ne 0 ]; then
+	echo "::error::Failed to read the current plugin/theme state over SSH (exit $ssh_status)"
+	exit 1
+fi
+
+section() { awk -v want="$1" 'BEGIN{n=0} /^@@SPLIT@@$/{n++;next} n==want' <<<"$remote_state"; }
+installed_plugins_json="$(section 0)"
+installed_themes_json="$(section 1)"
+server_symlinks="$(section 2)"
+
+if ! jq -e . >/dev/null 2>&1 <<<"$installed_plugins_json"; then
+	echo "::error::Could not parse 'wp plugin list' output from the server. Is WP-CLI available at $WP_PATH?"
+	exit 1
+fi
+
+# wp-content-relative symlink paths, e.g. plugins/jetpack
+symlinked_paths=()
+while IFS= read -r link; do
+	[ -n "$link" ] || continue
+	symlinked_paths+=("${link#wp-content/}")
+done <<<"$server_symlinks"
+
+is_symlinked() {
+	local rel="$1" p
+	[ "$PRESERVE_SYMLINKS" = "true" ] || return 1
+	[ ${#symlinked_paths[@]} -gt 0 ] || return 1
+	for p in "${symlinked_paths[@]}"; do
+		[ "$p" = "$rel" ] && return 0
+	done
+	return 1
+}
+
+installed_version() {
+	local kind="$1" slug="$2" json
+	if [ "$kind" = "plugin" ]; then json="$installed_plugins_json"; else json="$installed_themes_json"; fi
+	jq -r --arg s "$slug" '(.[] | select(.name == $s) | .version) // empty' <<<"$json" | head -1
+}
+
+# --- plan ------------------------------------------------------------------
+
+PLAN="$(mktemp)"
+trap 'rm -f "$PLAN"' EXIT
+
+skipped_protected=0
+skipped_current=0
+skipped_nodist=0
+to_install=0
+to_update=0
+
+echo
+echo "➤ Comparing composer.lock against the server"
+
+while IFS=$'\t' read -r name type version dist_url; do
+	slug="${name##*/}"
+	kind="plugin"
+	[ "$type" = "wordpress-theme" ] && kind="theme"
+	rel="${kind}s/$slug"
+
+	if [[ ! "$slug" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		echo "::warning::Skipping $name — '$slug' is not a usable directory name"
+		continue
+	fi
+
+	if is_symlinked "$rel"; then
+		echo "  ⤵︎ $rel — platform symlink, left alone"
+		skipped_protected=$((skipped_protected + 1))
+		continue
+	fi
+
+	if is_protected_path "$rel"; then
+		echo "  ⤵︎ $rel — protected by configuration, left alone"
+		skipped_protected=$((skipped_protected + 1))
+		continue
+	fi
+
+	# A package with no dist archive (typically a dev-* VCS requirement) cannot
+	# be installed by WP-CLI. build-release keeps those in the release, so they
+	# arrive over rsync instead — nothing to do here.
+	if [ -z "$dist_url" ] || [ "$dist_url" = "null" ]; then
+		echo "  ⤵︎ $rel — no dist archive in the lock, shipped in the release instead"
+		skipped_nodist=$((skipped_nodist + 1))
+		continue
+	fi
+
+	current="$(installed_version "$kind" "$slug")"
+	if [ -n "$current" ] && [ "$(normalize_version "$current")" = "$(normalize_version "$version")" ]; then
+		skipped_current=$((skipped_current + 1))
+		continue
+	fi
+
+	if [ -n "$current" ]; then
+		echo "  ↻ $rel — $current → $version"
+		printf 'update\t%s\t%s\t%s\t%s\n' "$kind" "$slug" "$version" "$dist_url" >> "$PLAN"
+		to_update=$((to_update + 1))
+	else
+		echo "  + $rel — install $version"
+		printf 'install\t%s\t%s\t%s\t%s\n' "$kind" "$slug" "$version" "$dist_url" >> "$PLAN"
+		to_install=$((to_install + 1))
+	fi
+done < <(jq -r '
+	.packages[]
+	| select(.type == "wordpress-plugin" or .type == "wordpress-theme")
+	| [.name, .type, .version, (.dist.url // "")]
+	| @tsv
+' "$COMPOSER_LOCK")
+
+echo
+echo "::notice::Plan: $to_install to install, $to_update to update, $skipped_current already at the locked version, $skipped_protected protected, $skipped_nodist shipped in the release"
+
+if [ "$DRY_RUN" = "true" ]; then
+	echo "::notice::dry-run: no changes made"
+	exit 0
+fi
+
+if [ "$to_install" -eq 0 ] && [ "$to_update" -eq 0 ]; then
+	echo "::notice::Nothing to do — the server already matches composer.lock"
+	exit 0
+fi
+
+# --- execute ---------------------------------------------------------------
+
+# Credentials for the private registry are injected into the dist URL, which is
+# then handed to the remote shell over STDIN rather than on the command line, so
+# it never lands in the server's process list or in a shell history.
+authenticated_url() {
+	local url="$1"
+	if [ -n "$PACKAGE_AUTH_USER" ] && [ -n "$PACKAGE_AUTH_HOST" ] && [[ "$url" == *"$PACKAGE_AUTH_HOST"* ]]; then
+		printf '%s' "${url/:\/\//://$PACKAGE_AUTH_USER:$PACKAGE_AUTH_PASSWORD@}"
+	else
+		printf '%s' "$url"
+	fi
+}
+
+echo
+echo "➤ Applying $((to_install + to_update)) change(s), one WP-CLI call per package"
+
+# Read the plan into an array (rather than piping it into the loop) so the ssh
+# calls below cannot consume the loop's stdin — the classic "ssh in a while-read
+# loop swallows the rest of the input" bug. Plain read loop rather than mapfile,
+# which needs bash 4.
+plan_lines=()
+while IFS= read -r line; do
+	[ -n "$line" ] && plan_lines+=("$line")
+done < "$PLAN"
+
+failed=()
+
+for line in "${plan_lines[@]}"; do
+	IFS=$'\t' read -r action kind slug version dist_url <<<"$line"
+	echo "  → $action $kind $slug@$version"
+	if printf '%s\n' "$(authenticated_url "$dist_url")" \
+		| ssh "$SSH_ALIAS" "cd '$WP_PATH' && IFS= read -r url && wp $kind install \"\$url\" --force 2>&1"; then
+		:
+	else
+		echo "::warning::wp $kind install failed for $slug@$version"
+		failed+=("$kind/$slug@$version")
+	fi
+done
+
+# --- verify ----------------------------------------------------------------
+
+# One extra exec re-reads the inventory and confirms the lock is now satisfied.
+# This is also what catches an archive whose top-level folder does not match the
+# package name — WP-CLI names the directory after the zip's root, and unlike
+# Composer it has no installer-paths to correct it.
+echo
+echo "➤ Verifying the server now matches composer.lock"
+
+verify_state=$(ssh -n "$SSH_ALIAS" "cd '$WP_PATH' || exit 9; \
+wp plugin list --format=json --fields=name,version,status --skip-plugins --skip-themes 2>/dev/null || echo '[]'; \
+echo '@@SPLIT@@'; \
+wp theme list --format=json --fields=name,version,status --skip-plugins --skip-themes 2>/dev/null || echo '[]'")
+
+verify_plugins="$(awk 'BEGIN{n=0} /^@@SPLIT@@$/{n++;next} n==0' <<<"$verify_state")"
+verify_themes="$(awk 'BEGIN{n=0} /^@@SPLIT@@$/{n++;next} n==1' <<<"$verify_state")"
+
+mismatched=()
+inactive=()
+for line in "${plan_lines[@]}"; do
+	IFS=$'\t' read -r action kind slug version dist_url <<<"$line"
+	if [ "$kind" = "plugin" ]; then json="$verify_plugins"; else json="$verify_themes"; fi
+	now="$(jq -r --arg s "$slug" '(.[] | select(.name == $s) | .version) // empty' <<<"$json" | head -1)"
+	status="$(jq -r --arg s "$slug" '(.[] | select(.name == $s) | .status) // empty' <<<"$json" | head -1)"
+	if [ -z "$now" ]; then
+		mismatched+=("$kind/$slug — expected $version, not present after install (the archive's top-level folder probably is not '$slug')")
+	elif [ "$(normalize_version "$now")" != "$(normalize_version "$version")" ]; then
+		mismatched+=("$kind/$slug — expected $version, server reports $now")
+	elif [ "$action" = "install" ] && [ "$status" = "inactive" ]; then
+		inactive+=("$kind/$slug")
+	fi
+done
+
+if [ ${#inactive[@]} -gt 0 ]; then
+	echo "::warning::Newly installed and NOT activated: ${inactive[*]}. This action never activates packages — activate them in wp-admin or with a post_deploy_command (wp plugin activate <slug>)."
+fi
+
+if [ ${#failed[@]} -gt 0 ] || [ ${#mismatched[@]} -gt 0 ]; then
+	for item in ${failed[@]+"${failed[@]}"}; do
+		echo "::error::Install failed: $item"
+	done
+	for item in ${mismatched[@]+"${mismatched[@]}"}; do
+		echo "::error::Version mismatch after install: $item"
+	done
+	exit 1
+fi
+
+echo "::notice::ℹ︎ Server matches composer.lock ($to_install installed, $to_update updated)"

--- a/actions/setup-wp-php/action.yml
+++ b/actions/setup-wp-php/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Tools for shivammathur/setup-php"
     required: false
     default: "composer, cs2pr"
+  install:
+    description: "Run the Composer install (true/false). Set false to get the pinned PHP and a warm Composer cache without installing — used by the remote-plugin-install build, where the server resolves packages from composer.lock and installing them on the runner would only be thrown away."
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -64,6 +68,7 @@ runs:
           composer-${{ runner.os }}-php${{ inputs.php-version }}-
 
     - name: Composer install
+      if: ${{ inputs.install != 'false' }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:

--- a/docs/MIGRATION-v3-to-v4.md
+++ b/docs/MIGRATION-v3-to-v4.md
@@ -67,6 +67,29 @@ survives the rewrite:
    entrypoint and update-readme.sh were fetched from the v3 *branch* at run
    time, so a pinned caller still executed unpinned code. v4 bundles all
    scripts inside composite actions (`github.action_path`).
+9. **Deploys rsynced over platform symlinks** — managed hosts link
+   platform-owned plugins (Pressable: jetpack, woocommerce) into `wp-content`.
+   rsync follows a symlinked destination, so `--delete` pruned files the
+   platform owned, and the mu-plugins tree sync could delete the host's own
+   mu-plugins outright. v4 detects symlinks and skips them.
+10. **Remote plugin install could only ever upgrade** —
+    `.deployment/remote-plugin-install.sh` compared versions with
+    `php -r version_compare` and acted only when the lock was *newer*, so
+    deploying an older release left every Composer-managed plugin ahead of the
+    code: rollbacks were a silent no-op for third-party packages. Its
+    authenticated fallback also called `wp plugin install` on the **runner**
+    rather than over SSH, so the fallback could never work; it opened a fresh
+    SSH connection per package; and it counted with `((var++))`, which returns
+    1 on the first increment and would abort any `set -e` port. v4's
+    `actions/remote-plugin-install` treats the lock as authoritative in both
+    directions, reuses one multiplexed connection, and verifies the result.
+11. **`REMOTE_PLUGIN_INSTALL` unset disabled the Composer install** —
+    `build.yml` gated PHP setup and the root `composer install` on
+    `vars.REMOTE_PLUGIN_INSTALL == 'false'`. The documented default is false,
+    but an *unset* variable is `''`, not `'false'`, so any repo that had never
+    defined it built with no dependencies installed and whatever PHP the runner
+    image shipped. The step is now unconditional; only the install itself is
+    conditional, through setup-wp-php's new `install` input.
 
 ## Behavioral changes (intentional)
 
@@ -108,6 +131,34 @@ survives the rewrite:
   used a draft release plus `create-release.yml` to attach-then-publish, but the
   draft broke release-please's changelog boundary detection (it re-scanned all
   history on every release), so the model was inverted.
+- **Symlinked folders are detected and never overwritten.** Managed hosts serve
+  some plugins from platform-owned storage and link them into `wp-content`
+  (Pressable does this for `jetpack` and `woocommerce`). v3 rsynced straight onto
+  those paths, which either wrote *through* the link into platform storage — with
+  `--delete` pruning files the platform owns — or replaced the link with a real
+  directory, detaching the site from platform updates. v4 scans `wp-content`
+  before syncing, skips every symlinked plugin/theme/mu-plugin, logs each one
+  with its target, and lists everything skipped in a closing summary. Paths that
+  are still real folders but are managed outside the repo can be declared in
+  `vars.PROTECTED_PATHS` (or per-deploy via the `protected_paths` input);
+  `preserve_symlinks: false` opts out of the automatic detection. Two related v3
+  behaviours changed as a consequence: Pressable's hardcoded
+  `rm -rf plugins/{jetpack,akismet}` became protected paths (same outcome, now
+  visible in the log), and Cloudways' legacy-symlink cleanup now only removes
+  links that point back into the deployment tree instead of any symlink at
+  `wp-content/{themes,plugins,mu-plugins}`.
+- **`REMOTE_PLUGIN_INSTALL` now works, and changes what the release contains.**
+  With it enabled, `build-release` drops every plugin/theme that `composer.lock`
+  covers *and* has a dist archive, keeping the lock instead; after the sync, the
+  deploy reconciles the server against the lock with one WP-CLI call per package
+  (`actions/remote-plugin-install`). The win is payload and sync volume, not build
+  time — Composer was already cached and the npm builds still run on the runner.
+  Deliberately **not** `composer install` over SSH (Pressable's "SSH build"): a
+  managed container caps one exec at ~300s, which a cold install for a large
+  project does not reliably fit inside, and it would fail mid-write with
+  maintenance mode on. Two requirements come with the mode: the project must use
+  per-plugin autoloaders (there is no root `vendor/` in this mode), and SSH key
+  auth is required (Cloudways `DEPLOYMENT_AUTH_TYPE=pass` fails loudly).
 - **phpcbf is no longer run in CI.** Run `composer fixcs` locally (ideally in
   a pre-commit hook via husky/lint-staged). The v3 flow — CI bot opening an
   "Auto Fix Formatting" PR that itself triggers more CI — was one of the most
@@ -267,11 +318,15 @@ Unchanged from v3 — same names, same levels:
   `PLUGIN_USES_COMPOSER`, `REMOTE_PLUGIN_INSTALL`,
   `DEPLOYMENT_AUTH_TYPE` (cloudways: key|pass), `INSTALL_NAME` (wpengine)
 - Environment vars: `SITE_ID`, `SITE_URL`, `BRANCH`
+- **New in v4:** `PROTECTED_PATHS` (repo or environment) — `wp-content`-relative
+  paths a deploy must never overwrite. Optional; symlinks are skipped without it.
 
 v4 reusable workflows declare their secrets explicitly (documenting the
 contract); `secrets: inherit` from callers still works. `vars.ENVIRONMENT`
-is no longer read. `SATISPRESS_USER`/`SATISPRESS_PASSWORD` are only used by
-the not-yet-ported remote-plugin-install path.
+is no longer read. `SATISPRESS_USER`/`SATISPRESS_PASSWORD` are used only by the
+`REMOTE_PLUGIN_INSTALL` reconcile — and because v4 declares secrets explicitly,
+they are now declared in `deploy.yml`/`deploy-continue.yml`; a caller that passes
+secrets individually rather than with `secrets: inherit` must add them.
 
 ## Versioning plan for v4
 
@@ -309,7 +364,10 @@ GA sequence after this PR merges into main:
 - [ ] Update Mantle to dispatch the continue workflow with explicit
       `inputs: {deployment_id, workflow_run_id}` (v3 dispatched without
       inputs, which could never work)
-- [ ] `REMOTE_PLUGIN_INSTALL=true` flow (`.deployment/remote-plugin-install.sh`)
+- [x] `REMOTE_PLUGIN_INSTALL=true` flow — ported to
+      [`actions/remote-plugin-install`](../actions/remote-plugin-install).
+      `.deployment/remote-plugin-install.sh` is superseded and no longer read by
+      anything in v4. Still needs validating against a live client site.
 - [ ] WP Engine / Cloudways equivalents for `do_backup` (was already a TODO in v3)
 - [ ] Make actionlint/zizmor blocking in `ci.yml` and pin actionlint by digest
 - [ ] Consider `ubuntu-24.04-arm` runners (~37% cheaper minutes) once v4 is stable


### PR DESCRIPTION
## What

Two related changes to the v4 deploy path, plus three bugs found on the way.

### 1. Deploys detect symlinked folders and leave them alone

Managed hosts serve some plugins from platform-owned storage and link them into `wp-content` — on Pressable, `jetpack` and `woocommerce` are usually symlinks rather than real folders. Syncing a release copy onto such a path is destructive either way: rsync follows the link and writes **through** it (so `--delete` prunes files the platform owns), or the link is replaced by a real directory and the site silently stops receiving platform updates.

All three host entrypoints now scan `wp-content` before syncing and skip anything symlinked:

- `plugins/` and `themes/` sync one folder at a time → a symlinked child is skipped whole
- `mu-plugins/` syncs as a tree → symlinked entries become rsync `--exclude` rules. **Without this, `--delete` was removing the host's own mu-plugins.**
- every symlink found is logged with its target; everything skipped is listed in a closing summary. A path the release ships but that wasn't deployed is annotated as a warning, so it can't quietly go missing.

Nothing to configure — it's on by default. `vars.PROTECTED_PATHS` covers paths that are real folders *today* but managed outside the repo (client installs it from wp-admin, a vendor ships it directly). Globs and bare names work; `preserve_symlinks: false` opts out.

### 2. `REMOTE_PLUGIN_INSTALL` ported to v4

New composite action [`actions/remote-plugin-install`](actions/remote-plugin-install), replacing the unported `.deployment/remote-plugin-install.sh`. With the flag on, `build-release` drops every plugin/theme that `composer.lock` covers **and** has a dist archive, keeping the lock; after the sync, the deploy reconciles the server against the lock with one short WP-CLI call per package.

**Deliberately not `composer install` over SSH** — i.e. not the "SSH build" in Pressable's Composer Workflows guide. Managed containers cap a single exec at ~300s (their own troubleshooting table: *"CLI job killed around 300 s — container exec timeout"*), which a cold install for a WooCommerce-scale project does not reliably fit inside, and it would fail mid-write with maintenance mode already on. One short call per package stays far inside the cap, keeps Composer and registry credentials off the server entirely, and leaves resolution on the runner where it's already cached.

**Setting expectations on "faster":** the win is payload and sync volume, not build time. The release zip, the transfer, the release asset retained for rollbacks, and the server-side write volume all shrink — a Renovate bump of one plugin becomes one `wp plugin install` instead of re-rsyncing the tree. Composer was never the slow part (cache is keyed on `composer.lock`) and the npm builds still run on the runner.

The two features meet where Composer's `installer-paths` would delete a platform symlink and drop a real directory in its place — WP-CLI would too — so every package is checked against the server's symlinks and `PROTECTED_PATHS` before install, with the same matching semantics as the rsync path.

## Bugs fixed

- **Rollbacks were a silent no-op for third-party plugins.** v3 compared with `php -r version_compare` and acted only when the lock was *newer*, so deploying an older `release_tag` left every Composer-managed plugin ahead of the code. The lock is now authoritative in both directions.
- **v3's authenticated fallback could never work** — it ran `wp plugin install` on the *runner*, not over SSH. It also opened a fresh SSH connection per package and counted with `((var++))`, which returns 1 on the first increment.
- ⚠️ **`build.yml` skipped the Composer install whenever `REMOTE_PLUGIN_INSTALL` was unset.** The step was gated on `vars.REMOTE_PLUGIN_INSTALL == 'false'`; the documented default is false, but an unset variable is `''`, not `'false'`. **Any repo that never defined it has been building with no dependencies installed and whatever PHP the runner image shipped.** Now unconditional; only the install itself is conditional, via a new `install` input on `setup-wp-php`. See "Needs a decision" below.
- **Pressable's mu-plugins tree sync could delete platform-managed mu-plugins** via `--delete` (covered by the symlink work).

## Testing

Four suites, all passing — they run the real scripts against fixtures, not reimplementations.

| Suite | Coverage |
| --- | --- |
| Pressable/WP Engine sync | 17 assertions: real symlinks incl. a broken one, platform storage left untouched, `--delete` not reaching through a link, protected real folders, server-only plugins preserved, glob/bare-name matching |
| Cloudways sync | 6 assertions: whole-tree `--delete` still prunes what the repo removed, while symlinked and protected children survive |
| Remote plugin install | 8 scenarios / 36 assertions against a stateful fake server: downgrade applied, idempotent re-run, dry-run, symlink + protected skips, dist-less `dev-*` packages, theme handling, failed download fails the deploy, mismatched archive folder caught by the verify pass, `wp-path` injection rejected |
| Build exclusion | Composer-managed packages dropped, our code + `composer.lock` + dist-less packages still ship, missing lock fails fast |

Two of those assertions are security checks: the registry password reaches the server **over stdin, never on the command line** (so it's absent from the server's process list), and wordpress.org URLs stay unauthenticated.

`actionlint` (with shellcheck on `run:` blocks) and `shellcheck` are clean; `yamllint` output is byte-identical to `main`. The shared symlink block is verified byte-identical across all three entrypoints.

## Needs a decision before merge

The `build.yml` fix changes what a deploy contains for any repo that never set `REMOTE_PLUGIN_INSTALL`: the root Composer install starts running, so third-party plugins and `vendor/` will appear in the release and get synced. If such a site has been managing those plugins by hand, the next deploy will overwrite them. v4 hasn't GA'd, so the blast radius should be limited to `linchpin.com` — but worth confirming before this lands.

## Caveats

- **Remote plugin install expects per-plugin autoloaders.** It skips the root Composer install, so there's no root `vendor/` and nothing creates one server-side. Matches the layout Pressable's guide recommends; a project depending on a *root* autoloader shouldn't enable it.
- **New packages install inactive** — the run warns and lists them; activate via `post_deploy_command`.
- **Key auth only** for remote plugin install; Cloudways `DEPLOYMENT_AUTH_TYPE=pass` fails loudly rather than skipping the reconcile.
- `SATISPRESS_USER`/`SATISPRESS_PASSWORD` are now declared in `deploy.yml`/`deploy-continue.yml`; callers passing secrets individually rather than `secrets: inherit` must add them.
- Consider `maintenance_mode: true` for the first few remote-install deploys — `wp plugin install --force` briefly replaces a plugin directory in place.
- **Not yet validated against a live site**, same caveat the migration doc already carries for the WP Engine and Cloudways composites. `dry-run: true` on the action is the safe first look.

## Docs

`README.md` gains [Symlinked and host-managed folders](README.md#symlinked-and-host-managed-folders) and [Remote plugin install](README.md#remote-plugin-install-composer-on-the-server). `docs/MIGRATION-v3-to-v4.md` records the behavioural changes, the three new entries in "v3 bugs fixed by v4", and ticks off the `REMOTE_PLUGIN_INSTALL` open item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
