### PR TITLE
feat(NO-TASK): Add a check-overrides action to find npm pins that went inert

### DIFF
--- a/.github/workflows/check-overrides.yml
+++ b/.github/workflows/check-overrides.yml
@@ -1,0 +1,136 @@
+# Check npm overrides (v4)
+#
+# Why this exists: transitive advisories in build tooling are remediated with
+# npm `overrides` pins, because the dependents (@wordpress/scripts and friends)
+# often keep declaring a vulnerable range long after a fix ships. That works,
+# but the pins are write-only in practice — nothing ever tells you the day
+# upstream catches up and the override stops doing anything. Projects end up
+# carrying a dozen pins where two are load-bearing, and every one of them is a
+# silent veto on a dependency the rest of the tree wants to move.
+#
+# This workflow probes each override independently and reports the ones that
+# have gone inert. It never fails a PR by default: an override held as a
+# security floor is legitimately kept even when the tree already satisfies it,
+# so the call belongs to a human.
+
+name: Check npm overrides
+
+on:
+  workflow_call:
+    inputs:
+      directories:
+        description: >-
+          Newline-separated list of directories to check, each with a
+          package.json and package-lock.json. Defaults to the repository root.
+        required: false
+        default: "."
+        type: string
+      node_version:
+        description: "Node version. Defaults to vars.NODE_VERSION, then 24"
+        required: false
+        default: ""
+        type: string
+      fail_on_redundant:
+        description: "Fail the job when an override is redundant or dangling"
+        required: false
+        default: false
+        type: boolean
+      open_issue:
+        description: >-
+          Open (or update) a single tracking issue listing removable overrides,
+          and close it once there are none. Intended for scheduled runs.
+        required: false
+        default: false
+        type: boolean
+      issue_label:
+        description: "Label used to find and mark the tracking issue"
+        required: false
+        default: "dependencies"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check-overrides:
+    name: npm overrides staleness
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Only needed when open_issue is true; harmless otherwise.
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check overrides
+        id: check
+        uses: linchpin/actions/actions/check-overrides@v4
+        with:
+          directories: ${{ inputs.directories }}
+          node-version: ${{ inputs.node_version || vars.NODE_VERSION || '24' }}
+          fail-on-redundant: ${{ inputs.fail_on_redundant }}
+          json-out: overrides-report.json
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: npm-overrides-report
+          path: overrides-report.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+      # A single reusable issue, kept in sync — so a monthly run does not create
+      # a new issue every month for the same unchanged set of pins.
+      - name: Sync tracking issue
+        if: ${{ inputs.open_issue }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Removable npm overrides"
+          LABEL: ${{ inputs.issue_label }}
+          REMOVABLE: ${{ steps.check.outputs.removable-count }}
+          NEEDED: ${{ steps.check.outputs.needed-count }}
+          RUN_URL: >-
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          existing="$(gh issue list --state open --label "$LABEL" \
+            --search "$TITLE in:title" --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")"
+
+          if [ "${REMOVABLE:-0}" -eq 0 ]; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" \
+                --body "All $NEEDED override(s) are load-bearing again as of $(date -u +%Y-%m-%d). Closing."
+              gh issue close "$existing"
+              echo "Closed #$existing — nothing removable."
+            else
+              echo "Nothing removable, no open issue. Done."
+            fi
+            exit 0
+          fi
+
+          {
+            echo "$REMOVABLE npm override(s) no longer appear to do anything."
+            echo
+            echo "Each was probed on its own: removed from a scratch copy of the"
+            echo "manifest, graph re-resolved, result compared against the pin."
+            echo
+            echo "**A redundant override is not automatically safe to delete.** One"
+            echo "added to hold a security floor still guards against a future"
+            echo "downgrade. Review each before removing."
+            echo
+            echo "Full table in the [workflow run summary]($RUN_URL)."
+            echo
+            echo "<sub>Updated automatically by check-overrides.yml.</sub>"
+          } > issue-body.md
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file issue-body.md
+            echo "Updated #$existing."
+          else
+            gh issue create --title "$TITLE" --label "$LABEL" --body-file issue-body.md
+          fi

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Linchpin WordPress projects use [Release Please](https://github.com/googleapis/r
 | [update-readme.yml](.github/workflows/update-readme.yml)   | Update the project README plugin table from composer.lock                                                      |
 | [auto-approve-maintenance.yml](.github/workflows/auto-approve-maintenance.yml) | Auto-approve PRs into a `maintenance/*` branch (or from a `security-update/*` branch) when only allow-listed dependency/config files changed |
 | [auto-merge-maintenance.yml](.github/workflows/auto-merge-maintenance.yml) | Cron-driven: auto-merges open Renovate PRs targeting a `maintenance/YYYY-MM` branch, excluding anything labeled `major`. Never touches main/master |
+| [check-overrides.yml](.github/workflows/check-overrides.yml) | Report npm `overrides` pins that no longer do anything, optionally tracking them in a single reusable issue     |
 | [ci.yml](.github/workflows/ci.yml)                         | This repo's own CI: actionlint + yamllint + zizmor                                                             |
 
 ### Composite Actions
@@ -225,6 +226,7 @@ Linchpin WordPress projects use [Release Please](https://github.com/googleapis/r
 | [deploy-cloudways](actions/deploy-cloudways)    | Upload + symlink-aware sync of a release to Cloudways (key or password SSH auth), health check |
 | [remote-plugin-install](actions/remote-plugin-install) | Reconcile third-party plugins/themes against composer.lock with per-package WP-CLI calls over SSH |
 | [update-readme](actions/update-readme)          | Regenerate the README plugin/theme table from composer.lock                        |
+| [check-overrides](actions/check-overrides)      | Probe each npm `overrides` pin and report the ones that are redundant or dangling  |
 
 ## Example Shared Workflow Usage
 
@@ -255,6 +257,42 @@ jobs:
       # Build this release, deploy it, and archive the zip on the release.
       build_for_release: ${{ github.event.release.tag_name }}
 ```
+
+### Checking npm overrides
+
+Transitive advisories in build tooling get pinned with npm `overrides`, because
+the dependents keep declaring a vulnerable range long after a fix ships. Nothing
+otherwise tells you the day upstream catches up and a pin stops doing anything,
+so they accumulate — and each one is a silent veto on a dependency the rest of
+the tree wants to move.
+
+Point it at every project in the repo that has its own lockfile:
+
+```yaml
+name: Check npm overrides
+on:
+  schedule:
+    - cron: "0 9 1 * *" # 09:00 UTC on the 1st
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  overrides:
+    uses: linchpin/actions/.github/workflows/check-overrides.yml@v4
+    with:
+      # A wp-content-shaped repo usually has several npm projects.
+      directories: |
+        .
+        themes/my-theme
+        plugins/my-functionality
+        plugins/my-functionality/blocks
+      open_issue: true
+```
+
+Findings are reported, never enforced: a redundant override may still be wanted
+as a security floor, so `fail_on_redundant` is off by default.
 
 To auto-merge non-major Renovate PRs into a monthly `maintenance/YYYY-MM`
 branch, add a caller workflow with its own `schedule` trigger (schedules

--- a/actions/check-overrides/action.yml
+++ b/actions/check-overrides/action.yml
@@ -1,0 +1,86 @@
+name: "Check npm overrides"
+description: >-
+  Report which entries in a package.json "overrides" block no longer do
+  anything, so pins added to dodge an advisory get removed once upstream
+  catches up instead of accumulating forever.
+
+  Each override is probed on its own: it is removed from a scratch copy of the
+  manifest, the graph is re-resolved with --package-lock-only, and the result is
+  compared against the pin. An override that still holds a package above its
+  pin is STILL NEEDED; one the tree already satisfies is REDUNDANT; one whose
+  package has left the tree entirely is DANGLING.
+
+  Reports by default and never fails the job — a redundant override may still be
+  wanted as a security floor, so removal is a judgement call for a human.
+
+inputs:
+  directories:
+    description: >-
+      Newline-separated list of directories to check, each containing a
+      package.json and package-lock.json. Monorepo-shaped WordPress projects
+      usually have several (root, theme, functionality plugin, blocks).
+    required: false
+    default: "."
+  node-version:
+    description: "Node version used to resolve the dependency graphs"
+    required: false
+    default: "24"
+  fail-on-redundant:
+    description: >-
+      Fail the job when any override is redundant or dangling (true/false).
+      Off by default: this is a hygiene signal, not a gate.
+    required: false
+    default: "false"
+  fail-on-error:
+    description: "Fail the job when an override probe itself errors (true/false)"
+    required: false
+    default: "false"
+  json-out:
+    description: "Optional path to write the machine-readable results to"
+    required: false
+    default: ""
+
+outputs:
+  removable-count:
+    description: "Number of overrides that are redundant or dangling"
+    value: ${{ steps.check.outputs.removable-count }}
+  redundant-count:
+    description: "Number of overrides the tree already satisfies"
+    value: ${{ steps.check.outputs.redundant-count }}
+  dangling-count:
+    description: "Number of overrides whose package has left the tree"
+    value: ${{ steps.check.outputs.dangling-count }}
+  needed-count:
+    description: "Number of overrides still holding a package above its pin"
+    value: ${{ steps.check.outputs.needed-count }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Probe overrides
+      id: check
+      shell: bash
+      env:
+        FAIL_ON_REDUNDANT: ${{ inputs.fail-on-redundant }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        OVERRIDES_JSON_OUT: ${{ inputs.json-out }}
+      run: |
+        # Turn the newline-separated input into arguments, dropping blanks and
+        # comments so callers can annotate the list in their workflow.
+        mapfile -t DIRS < <(printf '%s\n' "${{ inputs.directories }}" \
+          | sed -e 's/[[:space:]]*$//' -e '/^[[:space:]]*$/d' -e '/^[[:space:]]*#/d')
+
+        if [ "${#DIRS[@]}" -eq 0 ]; then
+          echo "::error::No directories to check"
+          exit 1
+        fi
+
+        printf 'Checking %d project(s):\n' "${#DIRS[@]}"
+        printf '  %s\n' "${DIRS[@]}"
+
+        node "${{ github.action_path }}/check-overrides.mjs" "${DIRS[@]}"

--- a/actions/check-overrides/check-overrides.mjs
+++ b/actions/check-overrides/check-overrides.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * Report which entries in a package.json "overrides" block no longer do
+ * anything, so pins added to dodge an advisory get cleaned up once upstream
+ * catches up instead of accumulating forever.
+ *
+ * For each override, in a scratch copy of the manifest + lockfile:
+ *   remove that ONE override -> re-resolve -> compare against the pin.
+ *
+ *   STILL NEEDED  removing it would drop the package below the pinned version
+ *   REDUNDANT     it already resolves at or above the pin without the override
+ *   DANGLING      the package is no longer in the dependency tree at all
+ *
+ * Two flags are load-bearing:
+ *   --package-lock-only  resolve the graph without downloading node_modules
+ *   --ignore-scripts     the scratch copy has no node_modules, so a `prepare`
+ *                        hook (husky is the common one) would fail the install
+ *                        and mask every result as an error
+ *
+ * The project itself is never mutated.
+ *
+ * Usage: node check-overrides.mjs <dir> [<dir> ...]
+ * Env:   GITHUB_STEP_SUMMARY  markdown report is appended when set
+ *        OVERRIDES_JSON_OUT   machine-readable results written here when set
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+	mkdtempSync,
+	cpSync,
+	existsSync,
+	readFileSync,
+	writeFileSync,
+	appendFileSync,
+	rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const dirs = process.argv.slice( 2 );
+
+if ( ! dirs.length ) {
+	console.error( 'usage: check-overrides.mjs <dir> [<dir> ...]' );
+	process.exit( 2 );
+}
+
+/** Strip an npm override key like `ajv@8` down to the bare package name. */
+const bareName = ( key ) => {
+	const at = key.lastIndexOf( '@' );
+	return at > 0 ? key.slice( 0, at ) : key;
+};
+
+/**
+ * Numeric semver compare, prerelease-insensitive. Overrides are pinned to
+ * exact release versions by convention, so major.minor.patch is enough and
+ * avoids taking on a semver dependency inside a composite action.
+ */
+const isBelow = ( version, pin ) => {
+	const parts = ( v ) => String( v ).replace( /^[^\d]*/, '' ).split( '-' )[ 0 ].split( '.' ).map( Number );
+	const [ a, b ] = [ parts( version ), parts( pin ) ];
+	for ( let i = 0; i < 3; i++ ) {
+		const [ x, y ] = [ a[ i ] || 0, b[ i ] || 0 ];
+		if ( x !== y ) return x < y;
+	}
+	return false;
+};
+
+/** Every resolved version of `name` in a lockfile, with its tree position. */
+const resolvedVersions = ( lockPath, name ) => {
+	const lock = JSON.parse( readFileSync( lockPath, 'utf8' ) );
+	const suffix = `node_modules/${ name }`;
+	return Object.entries( lock.packages ?? {} )
+		.filter( ( [ path ] ) => path === suffix || path.endsWith( `/${ suffix }` ) )
+		.map( ( [ path, meta ] ) => ( { path, version: meta.version } ) )
+		.filter( ( entry ) => entry.version );
+};
+
+const uniq = ( values ) => [ ...new Set( values ) ].join( ', ' );
+
+/** Probe every override in one project. */
+const checkProject = ( dir ) => {
+	const manifestPath = join( dir, 'package.json' );
+	const lockPath = join( dir, 'package-lock.json' );
+
+	if ( ! existsSync( manifestPath ) ) {
+		return { dir, skipped: 'no package.json', overrides: [] };
+	}
+	if ( ! existsSync( lockPath ) ) {
+		return { dir, skipped: 'no package-lock.json', overrides: [] };
+	}
+
+	const manifest = JSON.parse( readFileSync( manifestPath, 'utf8' ) );
+	const overrides = manifest.overrides ?? {};
+	const keys = Object.keys( overrides );
+
+	if ( ! keys.length ) {
+		return { dir, skipped: 'no overrides block', overrides: [] };
+	}
+
+	const work = mkdtempSync( join( tmpdir(), 'check-overrides-' ) );
+	const results = [];
+
+	try {
+		for ( const key of keys ) {
+			const name = bareName( key );
+			const pin = overrides[ key ];
+
+			// Fresh manifest + lockfile per probe, with this one override gone.
+			const probe = JSON.parse( readFileSync( manifestPath, 'utf8' ) );
+			delete probe.overrides[ key ];
+			writeFileSync( join( work, 'package.json' ), JSON.stringify( probe, null, 2 ) );
+			cpSync( lockPath, join( work, 'package-lock.json' ) );
+
+			let status;
+			let detail;
+
+			try {
+				execFileSync(
+					'npm',
+					[
+						'install',
+						'--package-lock-only',
+						'--ignore-scripts',
+						'--no-audit',
+						'--no-fund',
+					],
+					{
+						cwd: work,
+						encoding: 'utf8',
+						stdio: [ 'ignore', 'pipe', 'pipe' ],
+						maxBuffer: 64 * 1024 * 1024,
+					}
+				);
+
+				const found = resolvedVersions( join( work, 'package-lock.json' ), name );
+				const below = found.filter( ( entry ) => isBelow( entry.version, pin ) );
+
+				if ( ! found.length ) {
+					status = 'DANGLING';
+					detail = 'not in the dependency tree at all';
+				} else if ( ! below.length ) {
+					status = 'REDUNDANT';
+					detail = `already resolves to ${ uniq(
+						found.map( ( e ) => e.version )
+					) } without the override`;
+				} else {
+					status = 'STILL NEEDED';
+					detail = `would drop to ${ uniq(
+						below.map( ( e ) => e.version )
+					) } at ${ below.length } tree position(s)`;
+				}
+			} catch ( error ) {
+				status = 'ERROR';
+				detail = String( error.stderr || error.message || error )
+					.split( '\n' )
+					.filter( ( line ) => line && ! line.startsWith( 'npm warn' ) )
+					.slice( 0, 2 )
+					.join( ' ' )
+					.slice( 0, 300 );
+			}
+
+			results.push( { key, name, pin, status, detail } );
+			console.log( `${ dir }  ${ status.padEnd( 13 ) } ${ key.padEnd( 24 ) } ${ detail }` );
+		}
+	} finally {
+		rmSync( work, { recursive: true, force: true } );
+	}
+
+	return { dir, overrides: results };
+};
+
+const projects = dirs.map( checkProject );
+
+const all = projects.flatMap( ( p ) => p.overrides );
+const counts = {
+	redundant: all.filter( ( o ) => o.status === 'REDUNDANT' ).length,
+	dangling: all.filter( ( o ) => o.status === 'DANGLING' ).length,
+	needed: all.filter( ( o ) => o.status === 'STILL NEEDED' ).length,
+	errored: all.filter( ( o ) => o.status === 'ERROR' ).length,
+};
+
+// ---------------------------------------------------------------- reporting
+
+const ICON = {
+	REDUNDANT: '🟡',
+	DANGLING: '⚪',
+	'STILL NEEDED': '🟢',
+	ERROR: '🔴',
+};
+
+const lines = [ '## npm overrides staleness', '' ];
+
+if ( counts.redundant || counts.dangling ) {
+	lines.push(
+		`**${ counts.redundant + counts.dangling } override(s) look removable** ` +
+			`— ${ counts.redundant } redundant, ${ counts.dangling } dangling. ` +
+			`${ counts.needed } still doing work.`,
+		'',
+		'> A redundant override is not automatically safe to delete: one added to hold a',
+		'> security floor still guards against a future downgrade. Treat this as a prompt',
+		'> to review, not an instruction to remove.',
+		''
+	);
+} else if ( ! all.length ) {
+	lines.push( 'No `overrides` block found in any of the projects checked.', '' );
+} else {
+	lines.push( `All ${ counts.needed } override(s) are still doing work. Nothing to clean up.`, '' );
+}
+
+for ( const project of projects ) {
+	lines.push( `### \`${ project.dir }\`` );
+	if ( project.skipped ) {
+		lines.push( '', `_Skipped — ${ project.skipped }._`, '' );
+		continue;
+	}
+	lines.push( '', '| | Override | Pinned | Finding |', '| --- | --- | --- | --- |' );
+	for ( const o of project.overrides ) {
+		lines.push( `| ${ ICON[ o.status ] } | \`${ o.key }\` | \`${ o.pin }\` | ${ o.status } — ${ o.detail } |` );
+	}
+	lines.push( '' );
+}
+
+const report = lines.join( '\n' );
+console.log( `\n${ report }` );
+
+if ( process.env.GITHUB_STEP_SUMMARY ) {
+	appendFileSync( process.env.GITHUB_STEP_SUMMARY, `${ report }\n` );
+}
+
+if ( process.env.OVERRIDES_JSON_OUT ) {
+	writeFileSync(
+		process.env.OVERRIDES_JSON_OUT,
+		JSON.stringify( { counts, projects }, null, 2 )
+	);
+}
+
+if ( process.env.GITHUB_OUTPUT ) {
+	appendFileSync(
+		process.env.GITHUB_OUTPUT,
+		[
+			`redundant-count=${ counts.redundant }`,
+			`dangling-count=${ counts.dangling }`,
+			`needed-count=${ counts.needed }`,
+			`removable-count=${ counts.redundant + counts.dangling }`,
+			'',
+		].join( '\n' )
+	);
+}
+
+// Annotate so findings surface without opening the summary.
+for ( const project of projects ) {
+	for ( const o of project.overrides ) {
+		if ( o.status === 'REDUNDANT' || o.status === 'DANGLING' ) {
+			console.log(
+				`::notice title=Removable override::${ project.dir }: ${ o.key } (${ o.status.toLowerCase() }) — ${ o.detail }`
+			);
+		}
+		if ( o.status === 'ERROR' ) {
+			console.log(
+				`::warning title=Override probe failed::${ project.dir }: ${ o.key } — ${ o.detail }`
+			);
+		}
+	}
+}
+
+if ( counts.errored && process.env.FAIL_ON_ERROR === 'true' ) {
+	console.error( `\n${ counts.errored } override probe(s) failed.` );
+	process.exit( 1 );
+}
+
+if ( ( counts.redundant || counts.dangling ) && process.env.FAIL_ON_REDUNDANT === 'true' ) {
+	console.error( `\n${ counts.redundant + counts.dangling } override(s) look removable.` );
+	process.exit( 1 );
+}


### PR DESCRIPTION
## Why

Transitive advisories in build tooling get remediated with npm `overrides`, because the dependents — `@wordpress/scripts` and friends — often keep declaring a vulnerable range long after a fix ships upstream.

That works. The problem is the pins are **write-only in practice**: nothing tells you the day upstream catches up and an override stops doing anything. Projects accumulate a dozen pins where two are load-bearing, and every one of them is a silent veto on a dependency the rest of the tree wants to move.

This came out of [linchpin/linchpin.com#957](https://github.com/linchpin/linchpin.com/pull/957), where an `adm-zip` override was added for GHSA-xcpc-8h2w-3j85 — and the obvious follow-up question was "how will we ever know when to take it out again?"

## How it works

Each override is probed **independently**: removed from a scratch copy of the manifest, graph re-resolved with `--package-lock-only`, result compared against the pin.

| Verdict | Meaning |
| --- | --- |
| 🟢 `STILL NEEDED` | Removing it would drop the package below the pinned version |
| 🟡 `REDUNDANT` | The tree already satisfies the pin without it |
| ⚪ `DANGLING` | The package has left the dependency tree entirely |

The project itself is never mutated — all probing happens in a temp dir.

Two flags are load-bearing:
- **`--package-lock-only`** — resolves the graph without downloading `node_modules`, keeping a 17-override sweep to seconds.
- **`--ignore-scripts`** — subtler, and it cost me a debugging cycle. The scratch copy has no `node_modules`, so a `prepare` hook (husky being the usual one) fails the install and masks *every* result as an error.

## Reports, doesn't enforce

`fail_on_redundant` exists but defaults to **false**. A redundant override may still be wanted as a security floor — it guards against a future downgrade even when the tree currently satisfies it. Removal is a judgement call for a human, and the report says so inline.

This matches the two-tier policy already in `linchpin.com`'s `dependency-audit.yml`: dev/build tooling is remediated opportunistically, never gated.

## What ships

- `actions/check-overrides/` — composite action, bundled Node script resolved via `github.action_path`, following the `update-readme` pattern
- `.github/workflows/check-overrides.yml` — reusable workflow (`workflow_call`), which can keep **one** tracking issue in sync rather than opening a fresh one every month for the same unchanged pins, and closes it when nothing is removable
- README entries in both tables plus a caller example

## Verification

Run against `linchpin.com` — four npm projects, 17 overrides each:

```
REDUNDANT     @babel/core     already resolves to 7.29.7 without the override
STILL NEEDED  adm-zip         would drop to 0.5.18 at 2 tree position(s)
DANGLING      uuid@8          not in the dependency tree at all
```

Root: 5 redundant, 1 dangling, 11 still needed. It correctly reports the just-added `adm-zip` pin as load-bearing, and will flip it to `REDUNDANT` on its own once `@wordpress/scripts` declares `^0.6` — which is the whole point.

Also verified:
- Edge cases — no `overrides` block, no `package.json`, no `package-lock.json`, no args (exit 2)
- `fail_on_redundant=true` exits 1; default exits 0 with findings present
- Step summary, `$GITHUB_OUTPUT` counts, JSON artifact, and `::notice` annotations all populate
- Both YAML files parse; no line exceeds the 125-char `yamllint` limit from `.ymllint.yml` (the blocking CI check); no trailing whitespace or tabs

`yamllint`, `actionlint`, and `zizmor` aren't installed locally, so I checked the rules by hand — CI is the real gate on those.

Task: NO-TASK

🤖 Generated with [Claude Code](https://claude.com/claude-code)